### PR TITLE
refactor: Change form label to match the type of password being entered

### DIFF
--- a/apps/web/src/app/security/components/enable-2fa.tsx
+++ b/apps/web/src/app/security/components/enable-2fa.tsx
@@ -114,7 +114,7 @@ const Enable2FA = () => {
               name="currentPassword"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Old Password</FormLabel>
+                  <FormLabel>Current Password</FormLabel>
                   <FormControl>
                     <Input
                       type="password"


### PR DESCRIPTION
It is the Current Password being entered, the Old Password is for the Update Password component.

Fixes #3 