### PR TITLE
feat: Skip TLS Verification for HTTP Monitor

### DIFF
--- a/apps/server/src/modules/healthcheck/executor/executor_test.go
+++ b/apps/server/src/modules/healthcheck/executor/executor_test.go
@@ -235,6 +235,7 @@ func TestExecutorRegistry_Execute(t *testing.T) {
 					"method": "GET",
 					"encoding": "json",
 					"accepted_statuscodes": ["2XX"],
+					"skipTlsVerify": true,
 					"authMethod": "none"
 				}`,
 			},

--- a/apps/server/src/modules/healthcheck/executor/http.go
+++ b/apps/server/src/modules/healthcheck/executor/http.go
@@ -378,7 +378,6 @@ func (h *HTTPExecutor) Execute(ctx context.Context, m *Monitor, proxyModel *Prox
 			TLSClientConfig: &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				RootCAs:      caCertPool,
-				InsecureSkipVerify: cfg.SkipTlsVerify,
 			},
 		}
 		mtlsTransportWithProxy := buildProxyTransport(mtlsTransport, proxyModel)

--- a/apps/server/src/modules/healthcheck/executor/http.go
+++ b/apps/server/src/modules/healthcheck/executor/http.go
@@ -118,7 +118,7 @@ type HTTPConfig struct {
 	Body                string   `json:"body" validate:"omitempty"`
 	AcceptedStatusCodes []string `json:"accepted_statuscodes" validate:"required,dive,oneof=2XX 3XX 4XX 5XX"`
 	MaxRedirects        int      `json:"max_redirects" validate:"omitempty,min=0"`
-	TlsVerify           bool     `json:"tlsVerify" validate:"required"`
+	SkipTlsVerify       bool     `json:"skipTlsVerify"`
 
 	// Authentication fields
 	AuthMethod        string `json:"authMethod" validate:"required,oneof=none basic oauth2-cc ntlm mtls"`
@@ -303,7 +303,7 @@ func (h *HTTPExecutor) Execute(ctx context.Context, m *Monitor, proxyModel *Prox
 	// Default transport with proxy if needed
 	transport := buildProxyTransport(&http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: !cfg.TlsVerify,
+			InsecureSkipVerify: cfg.SkipTlsVerify,
 		},
 	}, proxyModel)
 
@@ -378,7 +378,7 @@ func (h *HTTPExecutor) Execute(ctx context.Context, m *Monitor, proxyModel *Prox
 			TLSClientConfig: &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				RootCAs:      caCertPool,
-				InsecureSkipVerify: !cfg.TlsVerify,
+				InsecureSkipVerify: cfg.SkipTlsVerify,
 			},
 		}
 		mtlsTransportWithProxy := buildProxyTransport(mtlsTransport, proxyModel)

--- a/apps/web/src/app/monitors/components/http/index.tsx
+++ b/apps/web/src/app/monitors/components/http/index.tsx
@@ -49,6 +49,7 @@ const Http = () => {
       headers: data.httpOptions.headers,
       encoding: data.httpOptions.encoding,
       body: data.httpOptions.body,
+      skipTlsVerify: data.httpOptions.skipTlsVerify,
       authMethod: data.authentication.authMethod,
       ...(data.authentication.authMethod === "basic" && {
         basic_auth_user: data.authentication.basic_auth_user,
@@ -120,6 +121,7 @@ const Http = () => {
         encoding: parsedConfig.encoding || "json",
         headers: parsedConfig.headers || '{ "Content-Type": "application/json" }',
         body: parsedConfig.body || "",
+        skipTlsVerify: parsedConfig.skipTlsVerify || false,
       } as HttpOptionsForm;
 
       // Construct authentication object based on authMethod

--- a/apps/web/src/app/monitors/components/http/options.tsx
+++ b/apps/web/src/app/monitors/components/http/options.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   FormControl,
   FormField,
@@ -49,6 +50,7 @@ const bodyPlaceholder = `Example:
 const base = z.object({
   method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]),
   headers: z.string().refine(isJson, { message: "Invalid JSON" }),
+  skipTlsVerify: z.boolean().default(false),
 });
 
 const jsonSchema = base.extend({
@@ -85,6 +87,7 @@ export const httpOptionsDefaultValues: HttpOptionsForm = {
   encoding: "json",
   body: "",
   headers: '{ "Content-Type": "application/json" }',
+  skipTlsVerify: false,
 };
 
 const HttpOptions = () => {
@@ -219,6 +222,25 @@ Any plain text content here...`;
           <FormItem>
             <FormLabel>Headers</FormLabel>
             <Textarea {...field} placeholder={headersPlaceholder} />
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="httpOptions.skipTlsVerify"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Skip TLS Verification</FormLabel>
+            <FormControl>
+                <Checkbox
+                  checked={field.value}
+                  onChange={(checked) => {
+                    field.onChange(!!checked);
+                  }}
+                />
+            </FormControl>
             <FormMessage />
           </FormItem>
         )}

--- a/apps/web/src/app/monitors/components/http/schema.ts
+++ b/apps/web/src/app/monitors/components/http/schema.ts
@@ -53,6 +53,8 @@ export interface HttpExecutorConfig {
   headers?: string; // optional, must be valid JSON if present
   encoding: "json" | "form" | "xml" | "text"; // required
 
+  skipTlsVerify: boolean; // defaults to false
+
   body?: string; // optional
 
   accepted_statuscodes: Array<"2XX" | "3XX" | "4XX" | "5XX">; // required, at least one


### PR DESCRIPTION
Implements a checkbox to Skip TLS verification for a given HTTP monitor.

Still a work in progress. Resolves #12 