### PR TITLE
feat: add PagerDuty notification channel support

### DIFF
--- a/apps/server/src/modules/notification_channel/listener.go
+++ b/apps/server/src/modules/notification_channel/listener.go
@@ -38,6 +38,7 @@ func NewNotificationEventListener(p NotificationEventListenerParams) *Notificati
 	RegisterNotificationChannelProvider("webhook", providers.NewWebhookSender(p.Logger))
 	RegisterNotificationChannelProvider("slack", providers.NewSlackSender(p.Logger, p.Config))
 	RegisterNotificationChannelProvider("ntfy", providers.NewNTFYSender(p.Logger))
+	RegisterNotificationChannelProvider("pagerduty", providers.NewPagerDutySender(p.Logger, p.Config))
 
 	return &NotificationEventListener{
 		service:                    p.Service,

--- a/apps/server/src/modules/notification_channel/notification_channel.controller.go
+++ b/apps/server/src/modules/notification_channel/notification_channel.controller.go
@@ -273,7 +273,7 @@ func (ic *Controller) Test(ctx *gin.Context) {
 		Type: "http",
 	}
 	testHeartbeat := &heartbeat.Model{
-		Status: shared.MonitorStatusUp,
+		Status: shared.MonitorStatusDown,
 		Msg:    testMessage,
 	}
 

--- a/apps/server/src/modules/notification_channel/providers/pagerduty.go
+++ b/apps/server/src/modules/notification_channel/providers/pagerduty.go
@@ -1,0 +1,228 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"peekaping/src/config"
+	"peekaping/src/modules/heartbeat"
+	"peekaping/src/modules/monitor"
+	"peekaping/src/modules/shared"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// PagerDutyConfig holds the configuration for PagerDuty notifications
+type PagerDutyConfig struct {
+	IntegrationKey string `json:"pagerduty_integration_key" validate:"required"`
+	IntegrationURL string `json:"pagerduty_integration_url" validate:"required,url"`
+	Priority       string `json:"pagerduty_priority"`
+	AutoResolve    string `json:"pagerduty_auto_resolve"`
+}
+
+// PagerDutySender handles sending notifications to PagerDuty
+type PagerDutySender struct {
+	logger *zap.SugaredLogger
+	config *config.Config
+}
+
+// NewPagerDutySender creates a new PagerDutySender
+func NewPagerDutySender(logger *zap.SugaredLogger, config *config.Config) *PagerDutySender {
+	return &PagerDutySender{logger: logger, config: config}
+}
+
+func (p *PagerDutySender) Unmarshal(configJSON string) (any, error) {
+	return GenericUnmarshal[PagerDutyConfig](configJSON)
+}
+
+func (p *PagerDutySender) Validate(configJSON string) error {
+	cfg, err := p.Unmarshal(configJSON)
+	if err != nil {
+		return err
+	}
+	return GenericValidator(cfg.(*PagerDutyConfig))
+}
+
+// getMonitorURL extracts the URL from monitor for PagerDuty source field
+func (p *PagerDutySender) getMonitorURL(monitor *monitor.Model) string {
+	if monitor == nil {
+		return ""
+	}
+
+	// Try to extract URL from monitor config JSON
+	if monitor.Config != "" {
+		var config map[string]any
+		if err := json.Unmarshal([]byte(monitor.Config), &config); err == nil {
+			// Handle different monitor types
+			switch monitor.Type {
+			case "http":
+				// HTTP monitors have a 'url' field
+				if url, ok := config["url"].(string); ok && url != "" {
+					return url
+				}
+			case "tcp":
+				// TCP monitors have 'host' and 'port' fields
+				if hostname, ok := config["host"].(string); ok && hostname != "" {
+					if port, ok := config["port"].(float64); ok && port > 0 {
+						return fmt.Sprintf("%s:%.0f", hostname, port)
+					}
+					return hostname
+				}
+			case "ping":
+				// Ping monitors have a 'host' field
+				if hostname, ok := config["host"].(string); ok && hostname != "" {
+					return hostname
+				}
+			case "dns":
+				// DNS monitors have a 'host' field
+				if hostname, ok := config["host"].(string); ok && hostname != "" {
+					return hostname
+				}
+			}
+		}
+	}
+
+	// Fallback to monitor name if no URL/hostname found
+	return monitor.Name
+}
+
+// getEventAction determines the PagerDuty event action based on heartbeat status and config
+func (p *PagerDutySender) getEventAction(heartbeat *heartbeat.Model, cfg *PagerDutyConfig) string {
+	if heartbeat == nil {
+		return "trigger"
+	}
+
+	switch heartbeat.Status {
+	case shared.MonitorStatusUp:
+		if cfg.AutoResolve == "acknowledge" {
+			return "acknowledge"
+		} else if cfg.AutoResolve == "resolve" {
+			return "resolve"
+		}
+		return "" // No action for UP status unless auto-resolve is configured
+	case shared.MonitorStatusDown:
+		return "trigger"
+	default:
+		return "trigger"
+	}
+}
+
+// getTitle generates the title for the PagerDuty alert
+func (p *PagerDutySender) getTitle(heartbeat *heartbeat.Model) string {
+	if heartbeat == nil {
+		return "Peekaping Alert"
+	}
+
+	switch heartbeat.Status {
+	case shared.MonitorStatusUp:
+		return "Peekaping Monitor ✅ Up"
+	case shared.MonitorStatusDown:
+		return "Peekaping Monitor 🔴 Down"
+	case shared.MonitorStatusPending:
+		return "Peekaping Monitor ⏳ Pending"
+	case shared.MonitorStatusMaintenance:
+		return "Peekaping Monitor 🔧 Maintenance"
+	default:
+		return "Peekaping Alert"
+	}
+}
+
+// getSeverity determines the severity level for PagerDuty
+func (p *PagerDutySender) getSeverity(cfg *PagerDutyConfig) string {
+	if cfg.Priority == "" {
+		return "warning"
+	}
+	return cfg.Priority
+}
+
+func (p *PagerDutySender) Send(
+	ctx context.Context,
+	configJSON string,
+	message string,
+	monitor *monitor.Model,
+	heartbeat *heartbeat.Model,
+) error {
+	cfgAny, err := p.Unmarshal(configJSON)
+	if err != nil {
+		return err
+	}
+	cfg := cfgAny.(*PagerDutyConfig)
+
+	// Debug logging
+	jsonDebug, _ := json.MarshalIndent(cfg, "", "  ")
+	p.logger.Debugf("PagerDuty config: %s", string(jsonDebug))
+	p.logger.Infof("Sending PagerDuty notification to: %s", cfg.IntegrationURL)
+
+	// Determine event action
+	eventAction := p.getEventAction(heartbeat, cfg)
+	if eventAction == "" {
+		p.logger.Infof("No action required for PagerDuty notification")
+		return nil
+	}
+
+	// Generate title
+	title := p.getTitle(heartbeat)
+
+	// Get monitor URL for source field
+	monitorURL := p.getMonitorURL(monitor)
+	if monitorURL == "" && monitor != nil {
+		// Fallback to monitor name if URL is not available
+		monitorURL = monitor.Name
+	}
+
+	// Prepare PagerDuty payload
+	payload := map[string]any{
+		"payload": map[string]any{
+			"summary":  fmt.Sprintf("[%s] [%s] %s", title, monitor.Name, message),
+			"severity": p.getSeverity(cfg),
+			"source":   monitorURL,
+		},
+		"routing_key":  cfg.IntegrationKey,
+		"event_action": eventAction,
+		"dedup_key":    fmt.Sprintf("Peekaping/%s", monitor.ID),
+	}
+
+	// Add client information if base URL is available
+	if p.config.ClientURL != "" && monitor != nil {
+		payload["client"] = "Peekaping"
+		payload["client_url"] = fmt.Sprintf("%s/monitors/%s", strings.TrimRight(p.config.ClientURL, "/"), monitor.ID)
+	}
+
+	// Convert payload to JSON
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal PagerDuty payload: %w", err)
+	}
+
+	p.logger.Debugf("PagerDuty payload: %s", string(jsonPayload))
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, "POST", cfg.IntegrationURL, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Peekaping-PagerDuty/1.0")
+
+	p.logger.Debugf("Sending PagerDuty request: %s", req.URL.String())
+
+	// Send request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send PagerDuty notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("PagerDuty notification failed with status code: %d", resp.StatusCode)
+	}
+
+	p.logger.Infof("PagerDuty notification sent successfully")
+	return nil
+}

--- a/apps/server/src/modules/notification_channel/providers/pagerduty_test.go
+++ b/apps/server/src/modules/notification_channel/providers/pagerduty_test.go
@@ -1,0 +1,259 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"peekaping/src/modules/heartbeat"
+	"peekaping/src/modules/monitor"
+	"peekaping/src/modules/shared"
+
+	"go.uber.org/zap"
+)
+
+func TestPagerDutyConfig_Unmarshal(t *testing.T) {
+	sender := NewPagerDutySender(zap.NewNop().Sugar(), nil)
+
+	// Test valid config
+	validConfig := `{
+		"pagerduty_integration_key": "test-key-123",
+		"pagerduty_integration_url": "https://events.pagerduty.com/v2/enqueue",
+		"pagerduty_priority": "warning",
+		"pagerduty_auto_resolve": "resolve"
+	}`
+
+	cfg, err := sender.Unmarshal(validConfig)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal valid config: %v", err)
+	}
+
+	pagerDutyConfig, ok := cfg.(*PagerDutyConfig)
+	if !ok {
+		t.Fatal("Failed to cast to PagerDutyConfig")
+	}
+
+	if pagerDutyConfig.IntegrationKey != "test-key-123" {
+		t.Errorf("Expected integration key 'test-key-123', got '%s'", pagerDutyConfig.IntegrationKey)
+	}
+
+	if pagerDutyConfig.IntegrationURL != "https://events.pagerduty.com/v2/enqueue" {
+		t.Errorf("Expected integration URL 'https://events.pagerduty.com/v2/enqueue', got '%s'", pagerDutyConfig.IntegrationURL)
+	}
+
+	if pagerDutyConfig.Priority != "warning" {
+		t.Errorf("Expected priority 'warning', got '%s'", pagerDutyConfig.Priority)
+	}
+
+	if pagerDutyConfig.AutoResolve != "resolve" {
+		t.Errorf("Expected auto resolve 'resolve', got '%s'", pagerDutyConfig.AutoResolve)
+	}
+}
+
+func TestPagerDutyConfig_Validate(t *testing.T) {
+	sender := NewPagerDutySender(zap.NewNop().Sugar(), nil)
+
+	// Test valid config
+	validConfig := `{
+		"pagerduty_integration_key": "test-key-123",
+		"pagerduty_integration_url": "https://events.pagerduty.com/v2/enqueue"
+	}`
+
+	err := sender.Validate(validConfig)
+	if err != nil {
+		t.Fatalf("Valid config should not return error: %v", err)
+	}
+
+	// Test invalid config (missing required fields)
+	invalidConfig := `{
+		"pagerduty_integration_url": "https://events.pagerduty.com/v2/enqueue"
+	}`
+
+	err = sender.Validate(invalidConfig)
+	if err == nil {
+		t.Fatal("Invalid config should return error")
+	}
+
+	// Test invalid URL
+	invalidURLConfig := `{
+		"pagerduty_integration_key": "test-key-123",
+		"pagerduty_integration_url": "not-a-valid-url"
+	}`
+
+	err = sender.Validate(invalidURLConfig)
+	if err == nil {
+		t.Fatal("Invalid URL should return error")
+	}
+}
+
+func TestPagerDutySender_getEventAction(t *testing.T) {
+	sender := NewPagerDutySender(zap.NewNop().Sugar(), nil)
+
+	// Test DOWN status
+	downHeartbeat := &heartbeat.Model{Status: shared.MonitorStatusDown}
+	cfg := &PagerDutyConfig{AutoResolve: "0"}
+
+	action := sender.getEventAction(downHeartbeat, cfg)
+	if action != "trigger" {
+		t.Errorf("Expected action 'trigger' for DOWN status, got '%s'", action)
+	}
+
+	// Test UP status with no auto-resolve
+	upHeartbeat := &heartbeat.Model{Status: shared.MonitorStatusUp}
+	action = sender.getEventAction(upHeartbeat, cfg)
+	if action != "" {
+		t.Errorf("Expected no action for UP status with no auto-resolve, got '%s'", action)
+	}
+
+	// Test UP status with auto-resolve
+	cfg.AutoResolve = "resolve"
+	action = sender.getEventAction(upHeartbeat, cfg)
+	if action != "resolve" {
+		t.Errorf("Expected action 'resolve' for UP status with auto-resolve, got '%s'", action)
+	}
+
+	// Test UP status with auto-acknowledge
+	cfg.AutoResolve = "acknowledge"
+	action = sender.getEventAction(upHeartbeat, cfg)
+	if action != "acknowledge" {
+		t.Errorf("Expected action 'acknowledge' for UP status with auto-acknowledge, got '%s'", action)
+	}
+}
+
+func TestPagerDutySender_getTitle(t *testing.T) {
+	sender := NewPagerDutySender(zap.NewNop().Sugar(), nil)
+
+	// Test DOWN status
+	downHeartbeat := &heartbeat.Model{Status: shared.MonitorStatusDown}
+	title := sender.getTitle(downHeartbeat)
+	expected := "Peekaping Monitor 🔴 Down"
+	if title != expected {
+		t.Errorf("Expected title '%s', got '%s'", expected, title)
+	}
+
+	// Test UP status
+	upHeartbeat := &heartbeat.Model{Status: shared.MonitorStatusUp}
+	title = sender.getTitle(upHeartbeat)
+	expected = "Peekaping Monitor ✅ Up"
+	if title != expected {
+		t.Errorf("Expected title '%s', got '%s'", expected, title)
+	}
+
+	// Test PENDING status
+	pendingHeartbeat := &heartbeat.Model{Status: shared.MonitorStatusPending}
+	title = sender.getTitle(pendingHeartbeat)
+	expected = "Peekaping Monitor ⏳ Pending"
+	if title != expected {
+		t.Errorf("Expected title '%s', got '%s'", expected, title)
+	}
+
+	// Test MAINTENANCE status
+	maintenanceHeartbeat := &heartbeat.Model{Status: shared.MonitorStatusMaintenance}
+	title = sender.getTitle(maintenanceHeartbeat)
+	expected = "Peekaping Monitor 🔧 Maintenance"
+	if title != expected {
+		t.Errorf("Expected title '%s', got '%s'", expected, title)
+	}
+
+	// Test nil heartbeat
+	title = sender.getTitle(nil)
+	expected = "Peekaping Alert"
+	if title != expected {
+		t.Errorf("Expected title '%s', got '%s'", expected, title)
+	}
+}
+
+func TestPagerDutySender_getSeverity(t *testing.T) {
+	sender := NewPagerDutySender(zap.NewNop().Sugar(), nil)
+
+	// Test default severity
+	cfg := &PagerDutyConfig{}
+	severity := sender.getSeverity(cfg)
+	if severity != "warning" {
+		t.Errorf("Expected default severity 'warning', got '%s'", severity)
+	}
+
+	// Test custom severity
+	cfg.Priority = "critical"
+	severity = sender.getSeverity(cfg)
+	if severity != "critical" {
+		t.Errorf("Expected severity 'critical', got '%s'", severity)
+	}
+}
+
+func TestPagerDutyPayload_Structure(t *testing.T) {
+	sender := NewPagerDutySender(zap.NewNop().Sugar(), nil)
+
+	// Create test data
+	monitor := &monitor.Model{
+		ID:   "test-monitor-123",
+		Name: "Test Monitor",
+	}
+
+	heartbeat := &heartbeat.Model{
+		Status: shared.MonitorStatusDown,
+		Msg:    "Connection timeout",
+	}
+
+	cfg := &PagerDutyConfig{
+		IntegrationKey: "test-key-123",
+		Priority:       "warning",
+	}
+
+	// Get event action
+	eventAction := sender.getEventAction(heartbeat, cfg)
+
+	// Build expected payload structure
+	expectedPayload := map[string]any{
+		"payload": map[string]any{
+			"summary":  "[Peekaping Monitor 🔴 Down] [Test Monitor] Connection timeout",
+			"severity": "warning",
+			"source":   monitor.Name, // Fallback to monitor name
+		},
+		"routing_key":  cfg.IntegrationKey,
+		"event_action": eventAction,
+		"dedup_key":    "Peekaping/test-monitor-123",
+	}
+
+	// Marshal expected payload
+	expectedJSON, err := json.Marshal(expectedPayload)
+	if err != nil {
+		t.Fatalf("Failed to marshal expected payload: %v", err)
+	}
+
+	// Verify the structure is valid JSON
+	var parsedPayload map[string]any
+	err = json.Unmarshal(expectedJSON, &parsedPayload)
+	if err != nil {
+		t.Fatalf("Failed to parse expected payload JSON: %v", err)
+	}
+
+	// Verify required fields exist
+	payload, ok := parsedPayload["payload"].(map[string]any)
+	if !ok {
+		t.Fatal("Payload field should be a map")
+	}
+
+	if _, ok := payload["summary"]; !ok {
+		t.Error("Payload should contain 'summary' field")
+	}
+
+	if _, ok := payload["severity"]; !ok {
+		t.Error("Payload should contain 'severity' field")
+	}
+
+	if _, ok := payload["source"]; !ok {
+		t.Error("Payload should contain 'source' field")
+	}
+
+	if _, ok := parsedPayload["routing_key"]; !ok {
+		t.Error("Root should contain 'routing_key' field")
+	}
+
+	if _, ok := parsedPayload["event_action"]; !ok {
+		t.Error("Root should contain 'event_action' field")
+	}
+
+	if _, ok := parsedPayload["dedup_key"]; !ok {
+		t.Error("Root should contain 'dedup_key' field")
+	}
+}

--- a/apps/web/src/app/notification-channels/components/create-edit-notification-channel.tsx
+++ b/apps/web/src/app/notification-channels/components/create-edit-notification-channel.tsx
@@ -27,6 +27,7 @@ import * as TelegramForm from "../integrations/telegram-form";
 import * as WebhookForm from "../integrations/webhook-form";
 import * as SlackForm from "../integrations/slack-form";
 import * as NtfyForm from "../integrations/ntfy-form";
+import * as PagerDutyForm from "../integrations/pagerduty-form";
 import { useEffect } from "react";
 import { commonMutationErrorHandler } from "@/lib/utils";
 
@@ -36,6 +37,7 @@ const typeFormRegistry = {
   webhook: WebhookForm,
   slack: SlackForm,
   ntfy: NtfyForm,
+  pagerduty: PagerDutyForm,
 };
 
 const notificationSchema = z
@@ -51,6 +53,7 @@ const notificationSchema = z
       WebhookForm.schema,
       SlackForm.schema,
       NtfyForm.schema,
+      PagerDutyForm.schema,
     ] as const)
   );
 
@@ -152,7 +155,7 @@ export default function CreateEditNotificationChannel({
             <Select
               onValueChange={(val) => {
                 if (!val) return;
-                baseForm.setValue("type", val as "smtp" | "telegram" | "webhook" | "slack" | "ntfy");
+                baseForm.setValue("type", val as "smtp" | "telegram" | "webhook" | "slack" | "ntfy" | "pagerduty");
               }}
               value={type}
             >

--- a/apps/web/src/app/notification-channels/integrations/pagerduty-form.tsx
+++ b/apps/web/src/app/notification-channels/integrations/pagerduty-form.tsx
@@ -1,0 +1,167 @@
+import { Input } from "@/components/ui/input";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+  FormDescription,
+} from "@/components/ui/form";
+import { z } from "zod";
+import { useFormContext } from "react-hook-form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export const schema = z.object({
+  type: z.literal("pagerduty"),
+  pagerduty_integration_key: z.string().min(1, { message: "Integration key is required" }),
+  pagerduty_integration_url: z.string().url({ message: "Valid integration URL is required" }),
+  pagerduty_priority: z.string().optional(),
+  pagerduty_auto_resolve: z.string().optional(),
+});
+
+export type PagerDutyFormValues = z.infer<typeof schema>;
+
+export const defaultValues: PagerDutyFormValues = {
+  type: "pagerduty",
+  pagerduty_integration_key: "",
+  pagerduty_integration_url: "https://events.pagerduty.com/v2/enqueue",
+  pagerduty_priority: "warning",
+  pagerduty_auto_resolve: "0",
+};
+
+export const displayName = "PagerDuty";
+
+export default function PagerDutyForm() {
+  const form = useFormContext();
+
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="pagerduty_integration_key"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>
+              Integration Key <span className="text-red-500">*</span>
+            </FormLabel>
+            <FormControl>
+              <Input
+                placeholder="Enter your PagerDuty integration key"
+                type="password"
+                required
+                {...field}
+              />
+            </FormControl>
+            <FormDescription>
+              <span className="text-red-500">*</span> Required
+              <br />
+              <span className="mt-2 block">
+                Learn how to get your integration key:{" "}
+                <a
+                  href="https://support.pagerduty.com/docs/services-and-integrations"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline text-blue-600"
+                >
+                  PagerDuty Documentation
+                </a>
+              </span>
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="pagerduty_integration_url"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>
+              Integration URL <span className="text-red-500">*</span>
+            </FormLabel>
+            <FormControl>
+              <Input
+                placeholder="https://events.pagerduty.com/v2/enqueue"
+                type="url"
+                required
+                {...field}
+              />
+            </FormControl>
+            <FormDescription>
+              <span className="text-red-500">*</span> Required
+              <br />
+              The PagerDuty Events API v2 endpoint URL. Defaults to the standard endpoint.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="pagerduty_priority"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Priority</FormLabel>
+            <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select priority level" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="info">Info</SelectItem>
+                <SelectItem value="warning">Warning</SelectItem>
+                <SelectItem value="error">Error</SelectItem>
+                <SelectItem value="critical">Critical</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormDescription>
+              The severity level for PagerDuty incidents. Defaults to "warning".
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="pagerduty_auto_resolve"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Auto Resolve or Acknowledge</FormLabel>
+            <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select auto-resolve behavior" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="0">Do nothing</SelectItem>
+                <SelectItem value="acknowledge">Auto acknowledge</SelectItem>
+                <SelectItem value="resolve">Auto resolve</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormDescription>
+              Choose what action to take when a monitor comes back up:
+              <br />
+              • <strong>Do nothing:</strong> No action taken on UP status
+              <br />
+              • <strong>Auto acknowledge:</strong> Automatically acknowledge the incident
+              <br />
+              • <strong>Auto resolve:</strong> Automatically resolve the incident
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
- Registered a new PagerDuty notification channel provider in the notification event listener.
- Updated the notification channel form to include PagerDuty as a selectable option.
- Modified the test heartbeat status to reflect a down state for testing purposes.