### PR TITLE
Implement ignore_tls_errors feature in HTTP executor

### DIFF
--- a/apps/web/src/app/monitors/components/http/advanced.tsx
+++ b/apps/web/src/app/monitors/components/http/advanced.tsx
@@ -24,6 +24,7 @@ const acceptedStatusCodesOptions = [
 export const advancedSchema = z.object({
   accepted_statuscodes: z.array(z.string()),
   max_redirects: z.coerce.number().min(0).max(30),
+  ignore_tls_errors: z.boolean(),
 });
 
 export type AdvancedForm = z.infer<typeof advancedSchema>;
@@ -31,6 +32,7 @@ export type AdvancedForm = z.infer<typeof advancedSchema>;
 export const advancedDefaultValues: AdvancedForm = {
   accepted_statuscodes: ["2XX"],
   max_redirects: 10,
+  ignore_tls_errors: false,
 }
 
 const Advanced = () => {

--- a/apps/web/src/app/monitors/components/http/advanced.tsx
+++ b/apps/web/src/app/monitors/components/http/advanced.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/form";
 import { FormItem } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { TypographyH4 } from "@/components/ui/typography";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
@@ -72,6 +73,29 @@ const Advanced = () => {
               Maximum number of redirects to follow (0-30). Set to 0 to disable redirects.
             </FormDescription>
             <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="ignore_tls_errors"
+        render={({ field }) => (
+          <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+            <FormControl>
+              <Checkbox
+                checked={field.value}
+                onCheckedChange={field.onChange}
+              />
+            </FormControl>
+            <div className="space-y-1 leading-none">
+              <FormLabel>
+                Ignore TLS/SSL errors for HTTPS websites
+              </FormLabel>
+              <FormDescription>
+                Skip TLS certificate validation. Use with caution - this makes connections less secure.
+              </FormDescription>
+            </div>
           </FormItem>
         )}
       />

--- a/apps/web/src/app/monitors/components/http/index.tsx
+++ b/apps/web/src/app/monitors/components/http/index.tsx
@@ -132,6 +132,7 @@ const Http = () => {
         proxy_id: monitor.data.proxy_id,
         accepted_statuscodes: parsedConfig.accepted_statuscodes,
         max_redirects: parsedConfig.max_redirects,
+        ignore_tls_errors: parsedConfig.ignore_tls_errors || false,
         httpOptions,
         authentication,
       });

--- a/apps/web/src/app/monitors/components/http/schema.ts
+++ b/apps/web/src/app/monitors/components/http/schema.ts
@@ -12,7 +12,6 @@ export const httpSchema = z
   .object({
     type: z.literal("http"),
     url: z.string().url({ message: "Invalid URL" }),
-    ignore_tls_errors: z.boolean().default(false),
   })
   .merge(generalSchema)
   .merge(intervalsSchema)
@@ -35,7 +34,6 @@ export type HttpForm = z.infer<typeof httpSchema>;
 export const httpDefaultValues: HttpForm = {
   type: "http",
   url: "https://example.com",
-  ignore_tls_errors: false,
 
   ...generalDefaultValues,
   ...intervalsDefaultValues,

--- a/apps/web/src/app/monitors/components/http/schema.ts
+++ b/apps/web/src/app/monitors/components/http/schema.ts
@@ -12,6 +12,7 @@ export const httpSchema = z
   .object({
     type: z.literal("http"),
     url: z.string().url({ message: "Invalid URL" }),
+    ignore_tls_errors: z.boolean().default(false),
   })
   .merge(generalSchema)
   .merge(intervalsSchema)
@@ -34,6 +35,7 @@ export type HttpForm = z.infer<typeof httpSchema>;
 export const httpDefaultValues: HttpForm = {
   type: "http",
   url: "https://example.com",
+  ignore_tls_errors: false,
 
   ...generalDefaultValues,
   ...intervalsDefaultValues,
@@ -114,6 +116,7 @@ export const deserialize = (data: MonitorMonitorResponseDto): HttpForm => {
     url: config.url || "https://example.com",
     accepted_statuscodes: config.accepted_statuscodes || ["2XX"],
     max_redirects: config.max_redirects || 10,
+    ignore_tls_errors: config.ignore_tls_errors || false,
     httpOptions: {
       method: config.method || "GET",
       encoding: config.encoding || "json",
@@ -133,6 +136,7 @@ export const serialize = (formData: HttpForm): MonitorCreateUpdateDto => {
     body: formData.httpOptions.body,
     accepted_statuscodes: formData.accepted_statuscodes as Array<"2XX" | "3XX" | "4XX" | "5XX">,
     max_redirects: formData.max_redirects,
+    ignore_tls_errors: formData.ignore_tls_errors,
     authMethod: formData.authentication.authMethod,
 
     // Include authentication fields based on method
@@ -187,6 +191,7 @@ export interface HttpExecutorConfig {
   accepted_statuscodes: Array<"2XX" | "3XX" | "4XX" | "5XX">; // required, at least one
 
   max_redirects?: number; // optional, must be >= 0 if present
+  ignore_tls_errors: boolean; // defaults to false
 
   // Authentication fields
   authMethod: "none" | "basic" | "oauth2-cc" | "ntlm" | "mtls"; // required


### PR DESCRIPTION
- Added support for the ignore_tls_errors configuration in the HTTP executor to allow skipping TLS certificate validation.
- Updated HTTPConfig struct to include ignore_tls_errors boolean.
- Enhanced test cases to validate behavior with and without ignoring TLS errors.
- Modified frontend components to include a checkbox for ignore_tls_errors in the HTTP monitor settings.

resolves #12 #24