### PR TITLE
feat: enhance monitoring statistics retrieval with interval support

### DIFF
--- a/apps/server/src/modules/monitor/monitor.service.go
+++ b/apps/server/src/modules/monitor/monitor.service.go
@@ -247,10 +247,22 @@ func (mr *MonitorServiceImpl) GetStatPoints(ctx context.Context, id string, sinc
 	default:
 		return nil, fmt.Errorf("invalid granularity: %s", granularity)
 	}
-	statsList, err := mr.statPointsService.FindStatsByMonitorIDAndTimeRange(ctx, id, since, until, period)
+
+	// Get monitor information to pass interval for minute-level grouping
+	monitor, err := mr.FindByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
+	if monitor == nil {
+		return nil, fmt.Errorf("monitor not found")
+	}
+
+	// Use the new method that accepts monitor interval
+	statsList, err := mr.statPointsService.FindStatsByMonitorIDAndTimeRangeWithInterval(ctx, id, since, until, period, monitor.Interval)
+	if err != nil {
+		return nil, err
+	}
+
 	points := make([]*StatPoint, 0, len(statsList))
 	for _, s := range statsList {
 		points = append(points, &StatPoint{

--- a/apps/server/src/modules/stats/stats.service.go
+++ b/apps/server/src/modules/stats/stats.service.go
@@ -219,7 +219,10 @@ func (s *ServiceImpl) groupStatsByInterval(minuteStats []*Stat, since, until tim
 		}
 	}
 
-	lastDataTime = time.Now()
+	// Don't extend beyond the requested until time
+	if lastDataTime.After(until) {
+		lastDataTime = until
+	}
 
 	// If no data found, return empty result
 	if !hasData {

--- a/apps/web/src/components/app-chart-example.tsx
+++ b/apps/web/src/components/app-chart-example.tsx
@@ -310,7 +310,7 @@ export function Chart({ id }: { id: string }) {
               type="monotone"
               stroke="var(--chart-4)"
               // strokeWidth={2}
-              dot={false}
+              dot={true}
               connectNulls={false}
               isAnimationActive={false}
             />
@@ -319,7 +319,7 @@ export function Chart({ id }: { id: string }) {
               type="monotone"
               stroke="var(--chart-3)"
               // strokeWidth={2}
-              dot={false}
+              dot={true}
               connectNulls={false}
               isAnimationActive={false}
             />
@@ -328,7 +328,7 @@ export function Chart({ id }: { id: string }) {
               type="monotone"
               stroke="var(--chart-2)"
               // strokeWidth={2}
-              dot={false}
+              dot={true}
               connectNulls={false}
               isAnimationActive={false}
             />


### PR DESCRIPTION
- Introduced a new method `FindStatsByMonitorIDAndTimeRangeWithInterval` in the stats service to allow grouping of minute-level stats based on monitor interval.
- Updated `GetStatPoints` in the monitor service to utilize the new method, improving the accuracy of statistical data retrieval.
- Added logic to group minute-level stats into monitor interval buckets for better data representation.
- Modified chart component to enable dot rendering for improved visual clarity in the app.