### PR TITLE
fix: correct pagination logic in repository methods

### DIFF
--- a/apps/server/src/modules/heartbeat/heartbeat.mongo.repository.go
+++ b/apps/server/src/modules/heartbeat/heartbeat.mongo.repository.go
@@ -119,7 +119,7 @@ func (r *RepositoryImpl) FindAll(ctx context.Context, page int, limit int) ([]*M
 	var entities []*Model
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Define options for pagination

--- a/apps/server/src/modules/heartbeat/heartbeat.sql.repository.go
+++ b/apps/server/src/modules/heartbeat/heartbeat.sql.repository.go
@@ -100,7 +100,7 @@ func (r *SQLRepositoryImpl) FindAll(ctx context.Context, page int, limit int) ([
 		Model(&sms).
 		Order("time DESC").
 		Limit(limit).
-		Offset((page - 1) * limit).
+		Offset(page * limit).
 		Scan(ctx)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func (r *SQLRepositoryImpl) FindByMonitorIDPaginated(
 		Model((*sqlModel)(nil)).
 		Where("monitor_id = ?", monitorID).
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	if important != nil {
 		query = query.Where("important = ?", *important)

--- a/apps/server/src/modules/maintenance/maintenance.mongo.repository.go
+++ b/apps/server/src/modules/maintenance/maintenance.mongo.repository.go
@@ -133,7 +133,7 @@ func (r *MongoRepositoryImpl) FindAll(ctx context.Context, page int, limit int, 
 	var entities []*Model
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Define options for pagination and sorting

--- a/apps/server/src/modules/maintenance/maintenance.sql.repository.go
+++ b/apps/server/src/modules/maintenance/maintenance.sql.repository.go
@@ -130,7 +130,7 @@ func (r *SQLRepositoryImpl) FindAll(ctx context.Context, page int, limit int, q 
 
 	query = query.Order("created_at DESC").
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	var sms []*sqlModel
 	err := query.Scan(ctx, &sms)

--- a/apps/server/src/modules/monitor/monitor.mongo.repository.go
+++ b/apps/server/src/modules/monitor/monitor.mongo.repository.go
@@ -185,7 +185,7 @@ func (r *MonitorRepositoryImpl) FindAll(
 	var monitors []*Model
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Define options for pagination

--- a/apps/server/src/modules/monitor/monitor.sql.repository.go
+++ b/apps/server/src/modules/monitor/monitor.sql.repository.go
@@ -162,7 +162,7 @@ func (r *SQLRepositoryImpl) FindAll(
 
 	query = query.Order("created_at DESC").
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	var sms []*sqlModel
 	err := query.Scan(ctx, &sms)

--- a/apps/server/src/modules/monitor_status_page/monitor_status_page.mongo.repository.go
+++ b/apps/server/src/modules/monitor_status_page/monitor_status_page.mongo.repository.go
@@ -103,7 +103,7 @@ func (r *MongoRepositoryImpl) FindAll(ctx context.Context, page int, limit int, 
 	var entities []*Model
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Define options for pagination

--- a/apps/server/src/modules/monitor_status_page/monitor_status_page.sql.repository.go
+++ b/apps/server/src/modules/monitor_status_page/monitor_status_page.sql.repository.go
@@ -70,7 +70,7 @@ func (r *SQLRepositoryImpl) FindAll(ctx context.Context, page int, limit int, q 
 
 	query = query.Order("created_at DESC").
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	var sms []*sqlModel
 	err := query.Scan(ctx, &sms)

--- a/apps/server/src/modules/notification_channel/notification_channel.mongo.repository.go
+++ b/apps/server/src/modules/notification_channel/notification_channel.mongo.repository.go
@@ -91,7 +91,7 @@ func (r *RepositoryImpl) FindAll(ctx context.Context, page int, limit int, q str
 	var entities []*mongoModel
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Build filter

--- a/apps/server/src/modules/notification_channel/notification_channel.sql.repository.go
+++ b/apps/server/src/modules/notification_channel/notification_channel.sql.repository.go
@@ -90,7 +90,7 @@ func (r *SQLRepositoryImpl) FindAll(ctx context.Context, page int, limit int, q 
 
 	query = query.Order("created_at DESC").
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	var sms []*sqlModel
 	err := query.Scan(ctx, &sms)

--- a/apps/server/src/modules/proxy/proxy.mongo.repository.go
+++ b/apps/server/src/modules/proxy/proxy.mongo.repository.go
@@ -104,7 +104,7 @@ func (r *MongoRepositoryImpl) FindAll(ctx context.Context, page int, limit int, 
 	var entities []*Model
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Define options for pagination

--- a/apps/server/src/modules/proxy/proxy.sql.repository.go
+++ b/apps/server/src/modules/proxy/proxy.sql.repository.go
@@ -93,7 +93,7 @@ func (r *SQLRepositoryImpl) FindAll(ctx context.Context, page int, limit int, q 
 
 	query = query.Order("created_at DESC").
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	var sms []*sqlModel
 	err := query.Scan(ctx, &sms)

--- a/apps/server/src/modules/status_page/status_page.sql.repository.go
+++ b/apps/server/src/modules/status_page/status_page.sql.repository.go
@@ -116,7 +116,7 @@ func (r *SQLRepositoryImpl) FindAll(
 
 	query = query.Order("created_at DESC").
 		Limit(limit).
-		Offset((page - 1) * limit)
+		Offset(page * limit)
 
 	var sms []*sqlModel
 	err := query.Scan(ctx, &sms)

--- a/apps/server/templates/module/mongo.repository.go.tmpl
+++ b/apps/server/templates/module/mongo.repository.go.tmpl
@@ -90,7 +90,7 @@ func (r *MongoRepositoryImpl) FindAll(ctx context.Context, page int, limit int, 
 	var entities []*Model
 
 	// Calculate the number of documents to skip
-	skip := int64((page) * limit)
+	skip := int64(page * limit)
 	limit64 := int64(limit)
 
 	// Define options for pagination


### PR DESCRIPTION
- Updated pagination calculations in multiple repository files to remove unnecessary parentheses around the page multiplication, ensuring consistent and accurate document skipping across MongoDB and SQL repositories.
- This change affects the FindAll methods in the heartbeat, maintenance, monitor, notification channel, proxy, and status page modules, improving the clarity and correctness of pagination logic.

fixes #52 