### PR TITLE
feat: add endpoint to retrieve monitors for a status page by slug for…

### DIFF
--- a/apps/server/docs/docs.go
+++ b/apps/server/docs/docs.go
@@ -2492,6 +2492,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/status-pages/slug/{slug}/monitors/homepage": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Status Pages"
+                ],
+                "summary": "Get monitors for a status page by slug for homepage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Status Page Slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ApiResponse-array_status_page_MonitorWithHeartbeatsAndUptimeDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/status-pages/{id}": {
             "get": {
                 "security": [

--- a/apps/server/docs/swagger.json
+++ b/apps/server/docs/swagger.json
@@ -2483,6 +2483,46 @@
                 }
             }
         },
+        "/status-pages/slug/{slug}/monitors/homepage": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Status Pages"
+                ],
+                "summary": "Get monitors for a status page by slug for homepage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Status Page Slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ApiResponse-array_status_page_MonitorWithHeartbeatsAndUptimeDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/status-pages/{id}": {
             "get": {
                 "security": [

--- a/apps/server/docs/swagger.yaml
+++ b/apps/server/docs/swagger.yaml
@@ -2797,6 +2797,32 @@ paths:
       summary: Get monitors for a status page by slug with heartbeats and uptime
       tags:
       - Status Pages
+  /status-pages/slug/{slug}/monitors/homepage:
+    get:
+      parameters:
+      - description: Status Page Slug
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/utils.ApiResponse-array_status_page_MonitorWithHeartbeatsAndUptimeDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/utils.APIError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.APIError'
+      summary: Get monitors for a status page by slug for homepage
+      tags:
+      - Status Pages
   /version:
     get:
       description: Returns the current server version

--- a/apps/server/src/modules/status_page/status_page.route.go
+++ b/apps/server/src/modules/status_page/status_page.route.go
@@ -23,6 +23,7 @@ func (r *Route) ConnectRoute(rg *gin.RouterGroup, controller *Controller) {
 	sp := rg.Group("status-pages")
 	sp.GET("/slug/:slug", r.controller.FindBySlug)
 	sp.GET("/slug/:slug/monitors", r.controller.GetMonitorsBySlug)
+	sp.GET("/slug/:slug/monitors/homepage", r.controller.GetMonitorsBySlugForHomepage)
 
 	sp.Use(r.middleware.Auth())
 	{


### PR DESCRIPTION
… homepage

- Introduced a new GET endpoint `/status-pages/slug/{slug}/monitors/homepage` to fetch monitors associated with a specific status page slug.
- Updated API documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to reflect the new endpoint and its parameters.
- Implemented the controller logic in `status_page.controller.go` to handle the request and return monitor data, including heartbeats and uptime statistics.
- Added routing for the new endpoint in `status_page.route.go`.