### PR TITLE
feat: add monitor event listener to server initialization

### DIFF
--- a/apps/server/src/main.go
+++ b/apps/server/src/main.go
@@ -121,6 +121,14 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Start the monitor event listener
+	err = container.Invoke(func(listener *monitor.MonitorEventListener, eventBus *events.EventBus) {
+		listener.Subscribe(eventBus)
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Start the server
 	err = container.Invoke(func(server *Server) {
 		docs.SwaggerInfo.Host = "localhost:" + server.cfg.Port

--- a/apps/server/src/modules/monitor/listener.go
+++ b/apps/server/src/modules/monitor/listener.go
@@ -1,0 +1,80 @@
+package monitor
+
+import (
+	"context"
+	"peekaping/src/modules/events"
+	"peekaping/src/modules/heartbeat"
+
+	"go.uber.org/dig"
+	"go.uber.org/zap"
+)
+
+// MonitorEventListener handles monitor status change events
+type MonitorEventListener struct {
+	monitorService Service
+	logger         *zap.SugaredLogger
+}
+
+type MonitorEventListenerParams struct {
+	dig.In
+	MonitorService Service
+	Logger         *zap.SugaredLogger
+}
+
+func NewMonitorEventListener(p MonitorEventListenerParams) *MonitorEventListener {
+	return &MonitorEventListener{
+		monitorService: p.MonitorService,
+		logger:         p.Logger.Named("[monitor-event-listener]"),
+	}
+}
+
+// Subscribe subscribes to MonitorStatusChanged events
+func (l *MonitorEventListener) Subscribe(eventBus *events.EventBus) {
+	eventBus.Subscribe(events.MonitorStatusChanged, l.handleMonitorStatusChanged)
+}
+
+func (l *MonitorEventListener) handleMonitorStatusChanged(event events.Event) {
+	ctx := context.Background()
+
+	hb, ok := event.Payload.(*heartbeat.Model)
+	if !ok {
+		l.logger.Errorf("Invalid handleMonitorStatusChanged event payload type: %v", event.Payload)
+		return
+	}
+
+	monitorID := hb.MonitorID
+	newStatus := hb.Status
+
+	l.logger.Infof("Monitor status changed event received for monitor: %s, new status: %d", monitorID, newStatus)
+
+	// Get the current monitor to check if status actually changed
+	currentMonitor, err := l.monitorService.FindByID(ctx, monitorID)
+	if err != nil {
+		l.logger.Errorf("Failed to get monitor %s: %v", monitorID, err)
+		return
+	}
+
+	if currentMonitor == nil {
+		l.logger.Warnf("Monitor %s not found", monitorID)
+		return
+	}
+
+	// Only update if status actually changed
+	if currentMonitor.Status == newStatus {
+		l.logger.Debugf("Monitor %s status unchanged (%d), skipping update", monitorID, newStatus)
+		return
+	}
+
+	// Update monitor status in database
+	updateModel := &PartialUpdateDto{
+		Status: &newStatus,
+	}
+
+	_, err = l.monitorService.UpdatePartial(ctx, monitorID, updateModel)
+	if err != nil {
+		l.logger.Errorf("Failed to update monitor %s status to %d: %v", monitorID, newStatus, err)
+		return
+	}
+
+	l.logger.Infof("Successfully updated monitor %s status from %d to %d", monitorID, currentMonitor.Status, newStatus)
+}

--- a/apps/server/src/modules/monitor/monitor.dig.go
+++ b/apps/server/src/modules/monitor/monitor.dig.go
@@ -12,4 +12,5 @@ func RegisterDependencies(container *dig.Container, cfg *config.Config) {
 	container.Provide(NewMonitorService)
 	container.Provide(NewMonitorController)
 	container.Provide(NewMonitorRoute)
+	container.Provide(NewMonitorEventListener)
 }


### PR DESCRIPTION
- Introduced a new monitor event listener in the server's main function to subscribe to the event bus, enhancing the monitoring capabilities of the application.
- Updated dependency injection to include the new MonitorEventListener, ensuring it is properly registered within the application context.

resolve #44 