### PR TITLE
feat: add bruteforce protection to login endpoint

### DIFF
--- a/apps/server/cmd/bun/migrations/20250724200709_add_bruteforce_protection.tx.down.sql
+++ b/apps/server/cmd/bun/migrations/20250724200709_add_bruteforce_protection.tx.down.sql
@@ -1,0 +1,9 @@
+-- Rollback migration: Remove bruteforce protection table
+-- This migration removes the bruteforce protection table and indexes
+-- Wrapped in a transaction for atomicity
+
+-- Drop index first
+DROP INDEX IF EXISTS login_state_locked_until_idx;
+
+-- Drop table
+DROP TABLE IF EXISTS login_state;

--- a/apps/server/cmd/bun/migrations/20250724200709_add_bruteforce_protection.tx.up.sql
+++ b/apps/server/cmd/bun/migrations/20250724200709_add_bruteforce_protection.tx.up.sql
@@ -1,0 +1,14 @@
+-- Migration: Add bruteforce protection table
+-- This migration adds a single table for tracking login state including failures and lockouts
+-- Wrapped in a transaction for atomicity
+
+-- Login state table to track failures and locks atomically
+CREATE TABLE IF NOT EXISTS login_state (
+    key           TEXT PRIMARY KEY,
+    fail_count    INT          NOT NULL,
+    first_fail_at TIMESTAMPTZ  NOT NULL,
+    locked_until  TIMESTAMPTZ
+);
+
+-- Create index for efficient expiration queries
+CREATE INDEX IF NOT EXISTS login_state_locked_until_idx ON login_state (locked_until);

--- a/apps/server/docs/docs.go
+++ b/apps/server/docs/docs.go
@@ -186,6 +186,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/utils.APIError"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.APIError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/apps/server/docs/swagger.json
+++ b/apps/server/docs/swagger.json
@@ -177,6 +177,12 @@
                             "$ref": "#/definitions/utils.APIError"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.APIError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/apps/server/docs/swagger.yaml
+++ b/apps/server/docs/swagger.yaml
@@ -1326,6 +1326,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/utils.APIError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.APIError'
         "500":
           description: Internal Server Error
           schema:

--- a/apps/server/src/config/config.go
+++ b/apps/server/src/config/config.go
@@ -36,6 +36,21 @@ type Config struct {
 	LogLevel string `env:"LOG_LEVEL" validate:"omitempty,log_level" default:"info"`
 
 	Timezone string `env:"TZ" validate:"required" default:"UTC"`
+
+	// Bruteforce protection settings
+	// Maximum number of failed login attempts allowed within the time window
+	// After exceeding this limit, the account will be temporarily locked
+	BruteforceMaxAttempts int `env:"BRUTEFORCE_MAX_ATTEMPTS" default:"20"`
+
+	// Time window for counting failed login attempts
+	// Only attempts within this window are counted towards the max attempts limit
+	// Examples: "1m", "5m", "1h", "24h"
+	BruteforceWindow time.Duration `env:"BRUTEFORCE_WINDOW" default:"1m"`
+
+	// Duration to lock the account after exceeding the maximum attempts
+	// During this period, all login attempts will be blocked with HTTP 429
+	// Examples: "5m", "30m", "1h", "24h"
+	BruteforceLockout time.Duration `env:"BRUTEFORCE_LOCKOUT" default:"1m"`
 }
 
 var validate = validator.New()

--- a/apps/server/src/main.go
+++ b/apps/server/src/main.go
@@ -8,6 +8,7 @@ import (
 	"peekaping/docs"
 	"peekaping/src/config"
 	"peekaping/src/modules/auth"
+	"peekaping/src/modules/bruteforce"
 	"peekaping/src/modules/cleanup"
 	"peekaping/src/modules/events"
 	"peekaping/src/modules/healthcheck"
@@ -78,6 +79,7 @@ func main() {
 	heartbeat.RegisterDependencies(container, &cfg)
 	monitor.RegisterDependencies(container, &cfg)
 	healthcheck.RegisterDependencies(container)
+	bruteforce.RegisterDependencies(container, &cfg)
 	auth.RegisterDependencies(container, &cfg)
 	notification_channel.RegisterDependencies(container, &cfg)
 	monitor_notification.RegisterDependencies(container, &cfg)

--- a/apps/server/src/modules/auth/auth.controller.go
+++ b/apps/server/src/modules/auth/auth.controller.go
@@ -100,6 +100,7 @@ func (c *Controller) Register(ctx *gin.Context) {
 // @Param       body body     LoginDto  true  "Login data"
 // @Success		200	{object}	utils.ApiResponse[LoginResponse]
 // @Failure		400	{object}	utils.APIError[any]
+// @Failure		401	{object}	utils.APIError[any]
 // @Failure		500	{object}	utils.APIError[any]
 func (c *Controller) Login(ctx *gin.Context) {
 	var dto LoginDto
@@ -116,7 +117,7 @@ func (c *Controller) Login(ctx *gin.Context) {
 	response, err := c.service.Login(ctx, dto)
 	if err != nil {
 		c.logger.Errorw("Failed to login admin", "error", err)
-		ctx.JSON(http.StatusBadRequest, utils.NewFailResponse(err.Error()))
+		ctx.JSON(http.StatusUnauthorized, utils.NewFailResponse(err.Error()))
 		return
 	}
 

--- a/apps/server/src/modules/auth/auth.route.go
+++ b/apps/server/src/modules/auth/auth.route.go
@@ -28,7 +28,6 @@ func (r *Route) ConnectRoute(router *gin.RouterGroup, controller *Controller) {
 	auth := router.Group("/auth")
 	auth.POST("/register", controller.Register)
 
-	// Apply bruteforce protection specifically to the login endpoint
 	auth.POST("/login", r.bruteforceGuard.Middleware(), controller.Login)
 
 	auth.POST("/refresh", controller.RefreshToken)

--- a/apps/server/src/modules/auth/auth.route.go
+++ b/apps/server/src/modules/auth/auth.route.go
@@ -1,28 +1,36 @@
 package auth
 
 import (
+	"peekaping/src/modules/bruteforce"
+
 	"github.com/gin-gonic/gin"
 )
 
 type Route struct {
-	controller *Controller
-	middleware *MiddlewareProvider
+	controller      *Controller
+	middleware      *MiddlewareProvider
+	bruteforceGuard *bruteforce.Guard
 }
 
 func NewRoute(
 	controller *Controller,
 	middleware *MiddlewareProvider,
+	bruteforceGuard *bruteforce.Guard,
 ) *Route {
 	return &Route{
 		controller,
 		middleware,
+		bruteforceGuard,
 	}
 }
 
 func (r *Route) ConnectRoute(router *gin.RouterGroup, controller *Controller) {
 	auth := router.Group("/auth")
 	auth.POST("/register", controller.Register)
-	auth.POST("/login", controller.Login)
+
+	// Apply bruteforce protection specifically to the login endpoint
+	auth.POST("/login", r.bruteforceGuard.Middleware(), controller.Login)
+
 	auth.POST("/refresh", controller.RefreshToken)
 
 	auth.Use(r.middleware.Auth())

--- a/apps/server/src/modules/bruteforce/bruteforce.config_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.config_test.go
@@ -1,0 +1,54 @@
+package bruteforce
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"peekaping/src/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBruteforceConfigFromEnv(t *testing.T) {
+	// Test default values
+	cfg := &config.Config{}
+	// Load defaults
+	cfg.BruteforceMaxAttempts = 5
+	cfg.BruteforceWindow = time.Minute
+	cfg.BruteforceLockout = 15 * time.Minute
+
+	params := GuardParams{
+		Service: &MockService{},
+		Logger:  nil, // We don't need logger for this test
+		cfg:     cfg,
+	}
+
+	guard := NewGuard(params)
+	assert.Equal(t, 5, guard.cfg.MaxAttempts)
+	assert.Equal(t, time.Minute, guard.cfg.Window)
+	assert.Equal(t, 15*time.Minute, guard.cfg.Lockout)
+
+	// Test custom values via environment variables
+	os.Setenv("BRUTEFORCE_MAX_ATTEMPTS", "3")
+	os.Setenv("BRUTEFORCE_WINDOW", "2m")
+	os.Setenv("BRUTEFORCE_LOCKOUT", "30m")
+	defer func() {
+		os.Unsetenv("BRUTEFORCE_MAX_ATTEMPTS")
+		os.Unsetenv("BRUTEFORCE_WINDOW")
+		os.Unsetenv("BRUTEFORCE_LOCKOUT")
+	}()
+
+	// Create a new config that will load from environment
+	testConfig := &config.Config{}
+	// Simulate loading from environment (in real app, this would be done by LoadConfig)
+	testConfig.BruteforceMaxAttempts = 3
+	testConfig.BruteforceWindow = 2 * time.Minute
+	testConfig.BruteforceLockout = 30 * time.Minute
+
+	params.cfg = testConfig
+	guard = NewGuard(params)
+	assert.Equal(t, 3, guard.cfg.MaxAttempts)
+	assert.Equal(t, 2*time.Minute, guard.cfg.Window)
+	assert.Equal(t, 30*time.Minute, guard.cfg.Lockout)
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.config_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.config_test.go
@@ -8,6 +8,7 @@ import (
 	"peekaping/src/config"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestBruteforceConfigFromEnv(t *testing.T) {
@@ -18,13 +19,10 @@ func TestBruteforceConfigFromEnv(t *testing.T) {
 	cfg.BruteforceWindow = time.Minute
 	cfg.BruteforceLockout = 15 * time.Minute
 
-	params := GuardParams{
-		Service: &MockService{},
-		Logger:  nil, // We don't need logger for this test
-		cfg:     cfg,
-	}
+	mockService := &MockService{}
+	logger := zap.NewNop().Sugar()
 
-	guard := NewGuard(params)
+	guard := NewGuard(mockService, logger, cfg)
 	assert.Equal(t, 5, guard.cfg.MaxAttempts)
 	assert.Equal(t, time.Minute, guard.cfg.Window)
 	assert.Equal(t, 15*time.Minute, guard.cfg.Lockout)
@@ -46,8 +44,7 @@ func TestBruteforceConfigFromEnv(t *testing.T) {
 	testConfig.BruteforceWindow = 2 * time.Minute
 	testConfig.BruteforceLockout = 30 * time.Minute
 
-	params.cfg = testConfig
-	guard = NewGuard(params)
+	guard = NewGuard(mockService, logger, testConfig)
 	assert.Equal(t, 3, guard.cfg.MaxAttempts)
 	assert.Equal(t, 2*time.Minute, guard.cfg.Window)
 	assert.Equal(t, 30*time.Minute, guard.cfg.Lockout)

--- a/apps/server/src/modules/bruteforce/bruteforce.dig.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.dig.go
@@ -30,15 +30,13 @@ func NewGuard(params GuardParams) *Guard {
 		MaxAttempts:     5,                // Allow 5 failed attempts
 		Window:          time.Minute,      // Within 1 minute window
 		Lockout:         15 * time.Minute, // Lock for 15 minutes
-		FailureStatuses: []int{400, 401},  // Consider 400 (validation errors) and 401 (invalid credentials) as failures
+		FailureStatuses: []int{401, 403},
 	}
 
 	// Use IP + email for key extraction to track per user per IP
 	keyExtractor := KeyByIPAndBodyField("email")
 
-	guard := New(cfg, params.Service, keyExtractor)
-
-	params.Logger.Info("Bruteforce protection initialized with 5 attempts per minute, 15 minute lockout")
+	guard := New(cfg, params.Service, keyExtractor, params.Logger)
 
 	return guard
 }

--- a/apps/server/src/modules/bruteforce/bruteforce.dig.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.dig.go
@@ -3,7 +3,6 @@ package bruteforce
 import (
 	"peekaping/src/config"
 	"peekaping/src/utils"
-	"time"
 
 	"go.uber.org/dig"
 	"go.uber.org/zap"
@@ -22,14 +21,15 @@ type GuardParams struct {
 
 	Service Service
 	Logger  *zap.SugaredLogger
+	cfg     *config.Config
 }
 
 // NewGuard creates a new bruteforce Guard with sensible defaults for login protection
 func NewGuard(params GuardParams) *Guard {
 	cfg := Config{
-		MaxAttempts:     5,                // Allow 5 failed attempts
-		Window:          time.Minute,      // Within 1 minute window
-		Lockout:         15 * time.Minute, // Lock for 15 minutes
+		MaxAttempts:     params.cfg.BruteforceMaxAttempts,
+		Window:          params.cfg.BruteforceWindow,
+		Lockout:         params.cfg.BruteforceLockout,
 		FailureStatuses: []int{401, 403},
 	}
 

--- a/apps/server/src/modules/bruteforce/bruteforce.dig.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.dig.go
@@ -1,0 +1,44 @@
+package bruteforce
+
+import (
+	"peekaping/src/config"
+	"peekaping/src/utils"
+	"time"
+
+	"go.uber.org/dig"
+	"go.uber.org/zap"
+)
+
+func RegisterDependencies(container *dig.Container, cfg *config.Config) {
+	utils.RegisterRepositoryByDBType(container, cfg, NewSQLRepository, NewMongoRepository)
+
+	container.Provide(NewService)
+	container.Provide(NewGuard)
+}
+
+// GuardParams holds dependencies for creating a bruteforce Guard
+type GuardParams struct {
+	dig.In
+
+	Service Service
+	Logger  *zap.SugaredLogger
+}
+
+// NewGuard creates a new bruteforce Guard with sensible defaults for login protection
+func NewGuard(params GuardParams) *Guard {
+	cfg := Config{
+		MaxAttempts:     5,                // Allow 5 failed attempts
+		Window:          time.Minute,      // Within 1 minute window
+		Lockout:         15 * time.Minute, // Lock for 15 minutes
+		FailureStatuses: []int{400, 401},  // Consider 400 (validation errors) and 401 (invalid credentials) as failures
+	}
+
+	// Use IP + email for key extraction to track per user per IP
+	keyExtractor := KeyByIPAndBodyField("email")
+
+	guard := New(cfg, params.Service, keyExtractor)
+
+	params.Logger.Info("Bruteforce protection initialized with 5 attempts per minute, 15 minute lockout")
+
+	return guard
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.dig.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.dig.go
@@ -15,28 +15,23 @@ func RegisterDependencies(container *dig.Container, cfg *config.Config) {
 	container.Provide(NewGuard)
 }
 
-// GuardParams holds dependencies for creating a bruteforce Guard
-type GuardParams struct {
-	dig.In
-
-	Service Service
-	Logger  *zap.SugaredLogger
-	cfg     *config.Config
-}
-
 // NewGuard creates a new bruteforce Guard with sensible defaults for login protection
-func NewGuard(params GuardParams) *Guard {
+func NewGuard(
+	Service Service,
+	Logger *zap.SugaredLogger,
+	config *config.Config,
+) *Guard {
 	cfg := Config{
-		MaxAttempts:     params.cfg.BruteforceMaxAttempts,
-		Window:          params.cfg.BruteforceWindow,
-		Lockout:         params.cfg.BruteforceLockout,
+		MaxAttempts:     config.BruteforceMaxAttempts,
+		Window:          config.BruteforceWindow,
+		Lockout:         config.BruteforceLockout,
 		FailureStatuses: []int{401, 403},
 	}
 
 	// Use IP + email for key extraction to track per user per IP
 	keyExtractor := KeyByIPAndBodyField("email")
 
-	guard := New(cfg, params.Service, keyExtractor, params.Logger)
+	guard := New(cfg, Service, keyExtractor, Logger)
 
 	return guard
 }

--- a/apps/server/src/modules/bruteforce/bruteforce.dig_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.dig_test.go
@@ -1,0 +1,19 @@
+package bruteforce
+
+import (
+	"peekaping/src/config"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/dig"
+)
+
+func TestRegisterDependencies(t *testing.T) {
+	container := dig.New()
+	cfg := &config.Config{DBType: "sqlite", DBName: "test"}
+
+	// This should not panic
+	assert.NotPanics(t, func() {
+		RegisterDependencies(container, cfg)
+	})
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.go
@@ -53,7 +53,7 @@ func New(cfg Config, service Service, ke KeyExtractor, logger *zap.SugaredLogger
 		cfg.Window = time.Minute
 	}
 	if cfg.Lockout <= 0 {
-		cfg.Lockout = 15 * time.Minute
+		cfg.Lockout = 1 * time.Minute
 	}
 	if cfg.FailureStatuses == nil {
 		cfg.FailureStatuses = []int{401, 403}

--- a/apps/server/src/modules/bruteforce/bruteforce.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.go
@@ -1,0 +1,172 @@
+package bruteforce
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Service interface for bruteforce protection
+type Service interface {
+	// IsLocked returns current lock (if any).
+	IsLocked(ctx context.Context, key string) (bool, time.Time, error)
+	// OnFailure atomically updates counters and may set a lock.
+	// Returns (locked, until, err).
+	OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error)
+	// Reset clears all state for the key (on successful auth).
+	Reset(ctx context.Context, key string) error
+}
+
+type KeyExtractor func(*gin.Context) (string, error)
+
+type Config struct {
+	MaxAttempts int
+	Window      time.Duration
+	Lockout     time.Duration
+	// Which HTTP statuses of the wrapped handler mean "authentication failed"
+	FailureStatuses []int
+	// Optional custom blocked response (otherwise 429 with Retry-After)
+	OnBlocked func(c *gin.Context, retryAfter time.Duration)
+}
+
+type Guard struct {
+	cfg          Config
+	service      Service
+	keyExtractor KeyExtractor
+}
+
+func New(cfg Config, service Service, ke KeyExtractor) *Guard {
+	// sensible defaults
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 5
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = time.Minute
+	}
+	if cfg.Lockout <= 0 {
+		cfg.Lockout = 15 * time.Minute
+	}
+	if cfg.FailureStatuses == nil {
+		cfg.FailureStatuses = []int{401, 403}
+	}
+	return &Guard{
+		cfg:          cfg,
+		service:      service,
+		keyExtractor: ke,
+	}
+}
+
+func (g *Guard) Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key, err := g.keyExtractor(c)
+		if err != nil || key == "" {
+			// If we cannot extract key, we fallback to IP only.
+			key = c.ClientIP()
+		}
+
+		ctx := c.Request.Context()
+
+		locked, until, err := g.service.IsLocked(ctx, key)
+		if err != nil {
+			// Fail safe: pass, log/monitor
+			c.Next()
+			return
+		}
+		if locked {
+			retryAfter := time.Until(until)
+			g.block(c, retryAfter)
+			return
+		}
+
+		c.Next()
+
+		// After handler runs, decide success/failure by status
+		status := c.Writer.Status()
+		if g.isFailure(status) {
+			now := time.Now()
+			// OnFailure atomically handles counting and locking
+			locked, until, err := g.service.OnFailure(ctx, key, now, g.cfg.Window, g.cfg.MaxAttempts, g.cfg.Lockout)
+			if err == nil && locked {
+				// If we just got locked, we could optionally notify the client
+				// For now, just let the request complete normally
+				_ = until // silence unused variable
+			}
+			return
+		}
+
+		// success -> reset
+		_ = g.service.Reset(ctx, key)
+	}
+}
+
+func (g *Guard) isFailure(status int) bool {
+	for _, s := range g.cfg.FailureStatuses {
+		if status == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *Guard) block(c *gin.Context, retryAfter time.Duration) {
+	if g.cfg.OnBlocked != nil {
+		g.cfg.OnBlocked(c, retryAfter)
+		return
+	}
+	c.Header("Retry-After", fmt.Sprintf("%.0f", retryAfter.Seconds()))
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+		"success":     false,
+		"message":     "too many attempts, try later",
+		"retry_after": int(retryAfter.Seconds()),
+	})
+}
+
+// KeyByIPAndBodyField makes a key "<ip>:<lower(username)>"
+// It safely reads the field from JSON body without consuming it by preserving the original body.
+func KeyByIPAndBodyField(field string) KeyExtractor {
+	return func(c *gin.Context) (string, error) {
+		ip := c.ClientIP()
+
+		// Only process JSON requests
+		if c.GetHeader("Content-Type") == "application/json" || strings.Contains(c.GetHeader("Content-Type"), "application/json") {
+			// Read body safely without consuming it
+			if c.Request.Body != nil {
+				bodyBytes, err := io.ReadAll(c.Request.Body)
+				if err != nil {
+					// On error, fallback to IP only
+					return ip, nil
+				}
+
+				// Restore the body for subsequent handlers
+				c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				// Try to parse JSON and extract field
+				var m map[string]any
+				if err := json.Unmarshal(bodyBytes, &m); err == nil {
+					if v, ok := m[field]; ok {
+						if s, ok := v.(string); ok && s != "" {
+							return fmt.Sprintf("%s:%s", ip, strings.ToLower(s)), nil
+						}
+					}
+				}
+			}
+		}
+
+		// For form requests, try PostForm (this doesn't interfere with JSON parsing)
+		if c.Request.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
+			if v := c.PostForm(field); v != "" {
+				return fmt.Sprintf("%s:%s", ip, strings.ToLower(v)), nil
+			}
+		}
+
+		// Fallback to IP only
+		return ip, nil
+	}
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.go
@@ -62,6 +62,7 @@ func New(cfg Config, service Service, ke KeyExtractor, logger *zap.SugaredLogger
 		cfg:          cfg,
 		service:      service,
 		keyExtractor: ke,
+		logger:       logger,
 	}
 }
 

--- a/apps/server/src/modules/bruteforce/bruteforce.guard_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.guard_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"peekaping/src/config"
 	"testing"
 	"time"
 
@@ -148,7 +149,7 @@ func TestNew_defaults(t *testing.T) {
 	guard := New(Config{}, &MockService{}, func(*gin.Context) (string, error) { return "k", nil }, zap.NewNop().Sugar())
 	assert.Equal(t, 5, guard.cfg.MaxAttempts)
 	assert.Equal(t, time.Minute, guard.cfg.Window)
-	assert.Equal(t, 15*time.Minute, guard.cfg.Lockout)
+	assert.Equal(t, 1*time.Minute, guard.cfg.Lockout)
 	assert.Equal(t, []int{401, 403}, guard.cfg.FailureStatuses)
 }
 
@@ -253,11 +254,17 @@ func TestNewGuard(t *testing.T) {
 	params := GuardParams{
 		Service: &MockService{},
 		Logger:  zap.NewNop().Sugar(),
+		cfg: &config.Config{
+			BruteforceMaxAttempts: 10,
+			BruteforceWindow:      2 * time.Minute,
+			BruteforceLockout:     30 * time.Minute,
+		},
 	}
+
 	guard := NewGuard(params)
 	assert.NotNil(t, guard)
-	assert.Equal(t, 5, guard.cfg.MaxAttempts)
-	assert.Equal(t, time.Minute, guard.cfg.Window)
-	assert.Equal(t, 15*time.Minute, guard.cfg.Lockout)
+	assert.Equal(t, 10, guard.cfg.MaxAttempts)
+	assert.Equal(t, 2*time.Minute, guard.cfg.Window)
+	assert.Equal(t, 30*time.Minute, guard.cfg.Lockout)
 	assert.Equal(t, []int{401, 403}, guard.cfg.FailureStatuses)
 }

--- a/apps/server/src/modules/bruteforce/bruteforce.guard_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.guard_test.go
@@ -1,0 +1,210 @@
+package bruteforce
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+// MockService implements the Service interface for Guard tests
+// Only methods used by Guard are implemented
+type MockService struct {
+	mock.Mock
+}
+
+func (m *MockService) IsLocked(ctx context.Context, key string) (bool, time.Time, error) {
+	args := m.Called(ctx, key)
+	return args.Bool(0), args.Get(1).(time.Time), args.Error(2)
+}
+func (m *MockService) OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error) {
+	args := m.Called(ctx, key, now, window, max, lockout)
+	return args.Bool(0), args.Get(1).(time.Time), args.Error(2)
+}
+func (m *MockService) Reset(ctx context.Context, key string) error {
+	args := m.Called(ctx, key)
+	return args.Error(0)
+}
+
+func TestGuard_isFailure(t *testing.T) {
+	guard := &Guard{cfg: Config{FailureStatuses: []int{401, 403}}}
+	assert.True(t, guard.isFailure(401))
+	assert.True(t, guard.isFailure(403))
+	assert.False(t, guard.isFailure(200))
+}
+
+func TestGuard_block_default(t *testing.T) {
+	guard := &Guard{cfg: Config{}}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	guard.block(c, 10*time.Second)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, false, resp["success"])
+	assert.Contains(t, resp["message"], "too many attempts")
+	assert.Equal(t, float64(10), resp["retry_after"])
+}
+
+func TestGuard_block_custom(t *testing.T) {
+	called := false
+	guard := &Guard{cfg: Config{OnBlocked: func(c *gin.Context, retryAfter time.Duration) {
+		called = true
+		c.String(444, "blocked")
+	}}}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	guard.block(c, 5*time.Second)
+	assert.True(t, called)
+	assert.Equal(t, 444, w.Code)
+	assert.Equal(t, "blocked", w.Body.String())
+}
+
+func TestKeyByIPAndBodyField_JSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := map[string]string{"email": "User@EXAMPLE.com"}
+	b, _ := json.Marshal(body)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	r.RemoteAddr = "1.2.3.4:5678"
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = r
+	key, err := KeyByIPAndBodyField("email")(c)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4:user@example.com", key)
+}
+
+func TestKeyByIPAndBodyField_JSON_no_field(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := map[string]string{"other": "value"}
+	b, _ := json.Marshal(body)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	r.RemoteAddr = "5.6.7.8:1234"
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = r
+	key, err := KeyByIPAndBodyField("email")(c)
+	assert.NoError(t, err)
+	assert.Equal(t, "5.6.7.8", key)
+}
+
+func TestKeyByIPAndBodyField_Form(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := httptest.NewRequest("POST", "/", bytes.NewReader([]byte("email=TestUser")))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.RemoteAddr = "9.8.7.6:4321"
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = r
+	c.Request.ParseForm()
+	c.Request.PostForm.Set("email", "TestUser")
+	key, err := KeyByIPAndBodyField("email")(c)
+	assert.NoError(t, err)
+	assert.Equal(t, "9.8.7.6:testuser", key)
+}
+
+func TestKeyByIPAndBodyField_Error(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := httptest.NewRequest("POST", "/", &errReader{})
+	r.Header.Set("Content-Type", "application/json")
+	r.RemoteAddr = "1.1.1.1:1111"
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = r
+	key, err := KeyByIPAndBodyField("email")(c)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.1.1.1", key)
+}
+
+type errReader struct{}
+
+func (e *errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("fail")
+}
+
+func (e *errReader) Close() error { return nil }
+
+func TestNew_defaults(t *testing.T) {
+	guard := New(Config{}, &MockService{}, func(*gin.Context) (string, error) { return "k", nil }, zap.NewNop().Sugar())
+	assert.Equal(t, 5, guard.cfg.MaxAttempts)
+	assert.Equal(t, time.Minute, guard.cfg.Window)
+	assert.Equal(t, 15*time.Minute, guard.cfg.Lockout)
+	assert.Equal(t, []int{401, 403}, guard.cfg.FailureStatuses)
+}
+
+func TestGuard_Middleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockSvc := &MockService{}
+	logger := zap.NewNop().Sugar()
+	key := "ip:user"
+	cfg := Config{MaxAttempts: 2, Window: time.Minute, Lockout: 2 * time.Minute, FailureStatuses: []int{401}}
+	guard := New(cfg, mockSvc, func(c *gin.Context) (string, error) { return key, nil }, logger)
+
+	// Not locked, success (should call Reset)
+	mockSvc.On("IsLocked", mock.Anything, key).Return(false, time.Time{}, nil)
+	mockSvc.On("Reset", mock.Anything, key).Return(nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+	c.Request = c.Request.WithContext(context.Background())
+	c.Writer.WriteHeader(200)
+	guard.Middleware()(c)
+	mockSvc.AssertCalled(t, "IsLocked", mock.Anything, key)
+	mockSvc.AssertCalled(t, "Reset", mock.Anything, key)
+
+	// Locked, should block
+	mockSvc = &MockService{}
+	guard = New(cfg, mockSvc, func(c *gin.Context) (string, error) { return key, nil }, logger)
+	mockSvc.On("IsLocked", mock.Anything, key).Return(true, time.Now().Add(time.Minute), nil)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+	c.Request = c.Request.WithContext(context.Background())
+	guard.Middleware()(c)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	// IsLocked error, should log and continue
+	mockSvc = &MockService{}
+	guard = New(cfg, mockSvc, func(c *gin.Context) (string, error) { return key, nil }, logger)
+	mockSvc.On("IsLocked", mock.Anything, key).Return(false, time.Time{}, errors.New("fail"))
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+	c.Request = c.Request.WithContext(context.Background())
+	guard.Middleware()(c)
+	assert.Equal(t, 200, w.Code)
+
+	// Failure status, should call OnFailure
+	mockSvc = &MockService{}
+	guard = New(cfg, mockSvc, func(c *gin.Context) (string, error) { return key, nil }, logger)
+	mockSvc.On("IsLocked", mock.Anything, key).Return(false, time.Time{}, nil)
+	mockSvc.On("OnFailure", mock.Anything, key, mock.Anything, cfg.Window, cfg.MaxAttempts, cfg.Lockout).Return(true, time.Now().Add(cfg.Lockout), nil)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+	c.Request = c.Request.WithContext(context.Background())
+	c.Writer.WriteHeader(401)
+	guard.Middleware()(c)
+	mockSvc.AssertCalled(t, "OnFailure", mock.Anything, key, mock.Anything, cfg.Window, cfg.MaxAttempts, cfg.Lockout)
+}
+
+func TestNewGuard(t *testing.T) {
+	// Test the NewGuard function from dig.go
+	params := GuardParams{
+		Service: &MockService{},
+		Logger:  zap.NewNop().Sugar(),
+	}
+	guard := NewGuard(params)
+	assert.NotNil(t, guard)
+	assert.Equal(t, 5, guard.cfg.MaxAttempts)
+	assert.Equal(t, time.Minute, guard.cfg.Window)
+	assert.Equal(t, 15*time.Minute, guard.cfg.Lockout)
+	assert.Equal(t, []int{401, 403}, guard.cfg.FailureStatuses)
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.guard_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.guard_test.go
@@ -251,17 +251,15 @@ func TestGuard_Middleware(t *testing.T) {
 
 func TestNewGuard(t *testing.T) {
 	// Test the NewGuard function from dig.go
-	params := GuardParams{
-		Service: &MockService{},
-		Logger:  zap.NewNop().Sugar(),
-		cfg: &config.Config{
-			BruteforceMaxAttempts: 10,
-			BruteforceWindow:      2 * time.Minute,
-			BruteforceLockout:     30 * time.Minute,
-		},
+	mockService := &MockService{}
+	logger := zap.NewNop().Sugar()
+	cfg := &config.Config{
+		BruteforceMaxAttempts: 10,
+		BruteforceWindow:      2 * time.Minute,
+		BruteforceLockout:     30 * time.Minute,
 	}
 
-	guard := NewGuard(params)
+	guard := NewGuard(mockService, logger, cfg)
 	assert.NotNil(t, guard)
 	assert.Equal(t, 10, guard.cfg.MaxAttempts)
 	assert.Equal(t, 2*time.Minute, guard.cfg.Window)

--- a/apps/server/src/modules/bruteforce/bruteforce.model.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.model.go
@@ -1,0 +1,18 @@
+package bruteforce
+
+import "time"
+
+// Model represents the login state for bruteforce protection
+type Model struct {
+	Key         string
+	FailCount   int
+	FirstFailAt time.Time
+	LockedUntil *time.Time
+}
+
+// UpdateModel represents fields that can be updated
+type UpdateModel struct {
+	FailCount   *int
+	FirstFailAt *time.Time
+	LockedUntil *time.Time
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.model_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.model_test.go
@@ -1,0 +1,65 @@
+package bruteforce
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_toDomainModelFromMongo_and_toMongoModel(t *testing.T) {
+	now := time.Now()
+	locked := now.Add(time.Hour)
+	mm := &mongoModel{Key: "k", FailCount: 1, FirstFailAt: now, LockedUntil: &locked}
+	m := toDomainModelFromMongo(mm)
+	assert.Equal(t, "k", m.Key)
+	assert.Equal(t, 1, m.FailCount)
+	assert.Equal(t, now, m.FirstFailAt)
+	assert.Equal(t, &locked, m.LockedUntil)
+
+	mm2 := toMongoModel(m)
+	assert.Equal(t, mm, mm2)
+}
+
+func Test_toDomainModel_and_toSQLModel(t *testing.T) {
+	now := time.Now()
+	locked := now.Add(time.Hour)
+	sm := &sqlModel{Key: "k", FailCount: 2, FirstFailAt: now, LockedUntil: &locked}
+	m := toDomainModel(sm)
+	assert.Equal(t, "k", m.Key)
+	assert.Equal(t, 2, m.FailCount)
+	assert.Equal(t, now, m.FirstFailAt)
+	assert.Equal(t, &locked, m.LockedUntil)
+
+	sm2 := toSQLModel(m)
+	assert.Equal(t, sm, sm2)
+}
+
+func TestModel_UpdateModel(t *testing.T) {
+	// Test Model struct
+	now := time.Now()
+	locked := now.Add(time.Hour)
+	m := &Model{
+		Key:         "test_key",
+		FailCount:   5,
+		FirstFailAt: now,
+		LockedUntil: &locked,
+	}
+	assert.Equal(t, "test_key", m.Key)
+	assert.Equal(t, 5, m.FailCount)
+	assert.Equal(t, now, m.FirstFailAt)
+	assert.Equal(t, &locked, m.LockedUntil)
+
+	// Test UpdateModel struct
+	failCount := 3
+	updateTime := now.Add(time.Minute)
+	updateLocked := now.Add(2 * time.Hour)
+	um := &UpdateModel{
+		FailCount:   &failCount,
+		FirstFailAt: &updateTime,
+		LockedUntil: &updateLocked,
+	}
+	assert.Equal(t, &failCount, um.FailCount)
+	assert.Equal(t, &updateTime, um.FirstFailAt)
+	assert.Equal(t, &updateLocked, um.LockedUntil)
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.mongo.repository.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.mongo.repository.go
@@ -1,0 +1,203 @@
+package bruteforce
+
+import (
+	"context"
+	"peekaping/src/config"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// mongoModel represents the MongoDB document for login state
+type mongoModel struct {
+	Key         string     `bson:"_id"` // Use key as the document ID for uniqueness
+	FailCount   int        `bson:"fail_count"`
+	FirstFailAt time.Time  `bson:"first_fail_at"`
+	LockedUntil *time.Time `bson:"locked_until,omitempty"`
+}
+
+func toDomainModelFromMongo(mm *mongoModel) *Model {
+	return &Model{
+		Key:         mm.Key,
+		FailCount:   mm.FailCount,
+		FirstFailAt: mm.FirstFailAt,
+		LockedUntil: mm.LockedUntil,
+	}
+}
+
+func toMongoModel(m *Model) *mongoModel {
+	return &mongoModel{
+		Key:         m.Key,
+		FailCount:   m.FailCount,
+		FirstFailAt: m.FirstFailAt,
+		LockedUntil: m.LockedUntil,
+	}
+}
+
+type MongoRepositoryImpl struct {
+	client               *mongo.Client
+	db                   *mongo.Database
+	loginStateCollection *mongo.Collection
+}
+
+func NewMongoRepository(client *mongo.Client, cfg *config.Config) Repository {
+	db := client.Database(cfg.DBName)
+	loginStateCollection := db.Collection("login_state")
+
+	repo := &MongoRepositoryImpl{
+		client:               client,
+		db:                   db,
+		loginStateCollection: loginStateCollection,
+	}
+
+	// Create indexes for better performance
+	repo.createIndexes()
+
+	return repo
+}
+
+func (r *MongoRepositoryImpl) createIndexes() {
+	// Create indexes for better performance on login_state collection
+	indexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "locked_until", Value: 1}},
+			Options: options.Index().SetExpireAfterSeconds(0), // Auto-expire when locked_until time is reached
+		},
+		{
+			Keys:    bson.D{{Key: "first_fail_at", Value: 1}},
+			Options: options.Index().SetExpireAfterSeconds(int32(24 * time.Hour / time.Second)), // Auto-expire old states after 24 hours
+		},
+	}
+
+	r.loginStateCollection.Indexes().CreateMany(context.Background(), indexes)
+}
+
+// FindByKey retrieves login state by key
+func (r *MongoRepositoryImpl) FindByKey(ctx context.Context, key string) (*Model, error) {
+	var mm mongoModel
+	err := r.loginStateCollection.FindOne(ctx, bson.M{"_id": key}).Decode(&mm)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return toDomainModelFromMongo(&mm), nil
+}
+
+// Create creates a new login state record
+func (r *MongoRepositoryImpl) Create(ctx context.Context, model *Model) (*Model, error) {
+	mm := toMongoModel(model)
+	_, err := r.loginStateCollection.InsertOne(ctx, mm)
+	if err != nil {
+		return nil, err
+	}
+	return toDomainModelFromMongo(mm), nil
+}
+
+// Update updates an existing login state record
+func (r *MongoRepositoryImpl) Update(ctx context.Context, key string, updateModel *UpdateModel) error {
+	update := bson.M{}
+	if updateModel.FailCount != nil {
+		update["fail_count"] = *updateModel.FailCount
+	}
+	if updateModel.FirstFailAt != nil {
+		update["first_fail_at"] = *updateModel.FirstFailAt
+	}
+	if updateModel.LockedUntil != nil {
+		update["locked_until"] = *updateModel.LockedUntil
+	}
+
+	_, err := r.loginStateCollection.UpdateOne(ctx, bson.M{"_id": key}, bson.M{"$set": update})
+	return err
+}
+
+// Delete removes a login state record
+func (r *MongoRepositoryImpl) Delete(ctx context.Context, key string) error {
+	_, err := r.loginStateCollection.DeleteOne(ctx, bson.M{"_id": key})
+	return err
+}
+
+// IsLocked checks if a key is currently locked
+func (r *MongoRepositoryImpl) IsLocked(ctx context.Context, key string) (bool, time.Time, error) {
+	var mm mongoModel
+	filter := bson.M{
+		"_id":          key,
+		"locked_until": bson.M{"$gt": time.Now()},
+	}
+
+	err := r.loginStateCollection.FindOne(ctx, filter).Decode(&mm)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return false, time.Time{}, nil
+		}
+		return false, time.Time{}, err
+	}
+
+	if mm.LockedUntil != nil {
+		return true, *mm.LockedUntil, nil
+	}
+
+	return false, time.Time{}, nil
+}
+
+// OnFailure atomically handles failure logic with window and locking
+func (r *MongoRepositoryImpl) OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error) {
+	var locked bool
+	var until time.Time
+
+	session, err := r.client.StartSession()
+	if err != nil {
+		return false, time.Time{}, err
+	}
+	defer session.EndSession(ctx)
+
+	_, err = session.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
+		var mm mongoModel
+		filter := bson.M{"_id": key}
+
+		err := r.loginStateCollection.FindOne(sc, filter).Decode(&mm)
+		windowStart := now.Add(-window)
+
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				// First failure for this key
+				mm = mongoModel{
+					Key:         key,
+					FailCount:   1,
+					FirstFailAt: now,
+					LockedUntil: nil,
+				}
+				_, err = r.loginStateCollection.InsertOne(sc, mm)
+				return nil, err
+			}
+			return nil, err
+		}
+
+		// Check if we're outside the window - reset if so
+		if mm.FirstFailAt.Before(windowStart) {
+			mm.FailCount = 1
+			mm.FirstFailAt = now
+			mm.LockedUntil = nil
+		} else {
+			// Within window, increment counter
+			mm.FailCount++
+
+			// Check if we need to lock
+			if mm.FailCount >= max {
+				lockUntil := now.Add(lockout)
+				mm.LockedUntil = &lockUntil
+				locked = true
+				until = lockUntil
+			}
+		}
+
+		update := bson.M{"$set": mm}
+		_, err = r.loginStateCollection.UpdateOne(sc, filter, update)
+		return nil, err
+	})
+
+	return locked, until, err
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.repository.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.repository.go
@@ -1,0 +1,26 @@
+package bruteforce
+
+import (
+	"context"
+	"time"
+)
+
+type Repository interface {
+	// FindByKey retrieves login state by key
+	FindByKey(ctx context.Context, key string) (*Model, error)
+
+	// Create creates a new login state record
+	Create(ctx context.Context, model *Model) (*Model, error)
+
+	// Update updates an existing login state record
+	Update(ctx context.Context, key string, updateModel *UpdateModel) error
+
+	// Delete removes a login state record
+	Delete(ctx context.Context, key string) error
+
+	// IsLocked checks if a key is currently locked
+	IsLocked(ctx context.Context, key string) (bool, time.Time, error)
+
+	// OnFailure atomically handles failure logic with window and locking
+	OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error)
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.service.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.service.go
@@ -1,0 +1,39 @@
+package bruteforce
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type ServiceImpl struct {
+	repo   Repository
+	logger *zap.SugaredLogger
+}
+
+func NewService(
+	repo Repository,
+	logger *zap.SugaredLogger,
+) Service {
+	return &ServiceImpl{
+		repo:   repo,
+		logger: logger.Named("[bruteforce-service]"),
+	}
+}
+
+// IsLocked returns current lock (if any).
+func (s *ServiceImpl) IsLocked(ctx context.Context, key string) (bool, time.Time, error) {
+	return s.repo.IsLocked(ctx, key)
+}
+
+// OnFailure atomically updates counters and may set a lock.
+// Returns (locked, until, err).
+func (s *ServiceImpl) OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error) {
+	return s.repo.OnFailure(ctx, key, now, window, max, lockout)
+}
+
+// Reset clears all state for the key (on successful auth).
+func (s *ServiceImpl) Reset(ctx context.Context, key string) error {
+	return s.repo.Delete(ctx, key)
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.service_test.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.service_test.go
@@ -1,0 +1,236 @@
+package bruteforce
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+// MockRepository is a mock implementation of the Repository interface
+// Only methods used by ServiceImpl are implemented
+type MockRepository struct {
+	mock.Mock
+}
+
+func (m *MockRepository) FindByKey(ctx context.Context, key string) (*Model, error) {
+	args := m.Called(ctx, key)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*Model), args.Error(1)
+}
+
+func (m *MockRepository) Create(ctx context.Context, model *Model) (*Model, error) {
+	args := m.Called(ctx, model)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*Model), args.Error(1)
+}
+
+func (m *MockRepository) Update(ctx context.Context, key string, updateModel *UpdateModel) error {
+	args := m.Called(ctx, key, updateModel)
+	return args.Error(0)
+}
+
+func (m *MockRepository) Delete(ctx context.Context, key string) error {
+	args := m.Called(ctx, key)
+	return args.Error(0)
+}
+
+func (m *MockRepository) IsLocked(ctx context.Context, key string) (bool, time.Time, error) {
+	args := m.Called(ctx, key)
+	return args.Bool(0), args.Get(1).(time.Time), args.Error(2)
+}
+
+func (m *MockRepository) OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error) {
+	args := m.Called(ctx, key, now, window, max, lockout)
+	return args.Bool(0), args.Get(1).(time.Time), args.Error(2)
+}
+
+func TestServiceImpl_IsLocked(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            string
+		mockReturn     []interface{}
+		expectedLocked bool
+		expectedUntil  time.Time
+		expectedError  error
+	}{
+		{
+			name:           "successful locked check",
+			key:            "test_key",
+			mockReturn:     []interface{}{true, time.Now().Add(5 * time.Minute), nil},
+			expectedLocked: true,
+			expectedUntil:  time.Now().Add(5 * time.Minute),
+			expectedError:  nil,
+		},
+		{
+			name:           "not locked",
+			key:            "test_key",
+			mockReturn:     []interface{}{false, time.Time{}, nil},
+			expectedLocked: false,
+			expectedUntil:  time.Time{},
+			expectedError:  nil,
+		},
+		{
+			name:           "repository error",
+			key:            "test_key",
+			mockReturn:     []interface{}{false, time.Time{}, errors.New("database error")},
+			expectedLocked: false,
+			expectedUntil:  time.Time{},
+			expectedError:  errors.New("database error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := &MockRepository{}
+			logger := zap.NewNop().Sugar()
+			service := NewService(mockRepo, logger)
+			ctx := context.Background()
+
+			mockRepo.On("IsLocked", ctx, tt.key).Return(tt.mockReturn...)
+
+			locked, until, err := service.IsLocked(ctx, tt.key)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedLocked, locked)
+			if tt.expectedUntil.IsZero() {
+				assert.True(t, until.IsZero())
+			} else {
+				assert.False(t, until.IsZero())
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestServiceImpl_OnFailure(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            string
+		now            time.Time
+		window         time.Duration
+		max            int
+		lockout        time.Duration
+		mockReturn     []interface{}
+		expectedLocked bool
+		expectedUntil  time.Time
+		expectedError  error
+	}{
+		{
+			name:           "successful failure with lock",
+			key:            "test_key",
+			now:            time.Now(),
+			window:         1 * time.Minute,
+			max:            5,
+			lockout:        10 * time.Minute,
+			mockReturn:     []interface{}{true, time.Now().Add(10 * time.Minute), nil},
+			expectedLocked: true,
+			expectedUntil:  time.Now().Add(10 * time.Minute),
+			expectedError:  nil,
+		},
+		{
+			name:           "failure without lock",
+			key:            "test_key",
+			now:            time.Now(),
+			window:         1 * time.Minute,
+			max:            5,
+			lockout:        10 * time.Minute,
+			mockReturn:     []interface{}{false, time.Time{}, nil},
+			expectedLocked: false,
+			expectedUntil:  time.Time{},
+			expectedError:  nil,
+		},
+		{
+			name:           "repository error",
+			key:            "test_key",
+			now:            time.Now(),
+			window:         1 * time.Minute,
+			max:            5,
+			lockout:        10 * time.Minute,
+			mockReturn:     []interface{}{false, time.Time{}, errors.New("database error")},
+			expectedLocked: false,
+			expectedUntil:  time.Time{},
+			expectedError:  errors.New("database error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := &MockRepository{}
+			logger := zap.NewNop().Sugar()
+			service := NewService(mockRepo, logger)
+			ctx := context.Background()
+
+			mockRepo.On("OnFailure", ctx, tt.key, tt.now, tt.window, tt.max, tt.lockout).Return(tt.mockReturn...)
+
+			locked, until, err := service.OnFailure(ctx, tt.key, tt.now, tt.window, tt.max, tt.lockout)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedLocked, locked)
+			if tt.expectedUntil.IsZero() {
+				assert.True(t, until.IsZero())
+			} else {
+				assert.False(t, until.IsZero())
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestServiceImpl_Reset(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		mockError     error
+		expectedError error
+	}{
+		{
+			name:          "successful reset",
+			key:           "test_key",
+			mockError:     nil,
+			expectedError: nil,
+		},
+		{
+			name:          "delete error",
+			key:           "test_key",
+			mockError:     errors.New("delete error"),
+			expectedError: errors.New("delete error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := &MockRepository{}
+			logger := zap.NewNop().Sugar()
+			service := NewService(mockRepo, logger)
+			ctx := context.Background()
+
+			mockRepo.On("Delete", ctx, tt.key).Return(tt.mockError)
+
+			err := service.Reset(ctx, tt.key)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}

--- a/apps/server/src/modules/bruteforce/bruteforce.sql.repository.go
+++ b/apps/server/src/modules/bruteforce/bruteforce.sql.repository.go
@@ -1,0 +1,182 @@
+package bruteforce
+
+import (
+	"context"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// sqlModel represents the database model for login state
+type sqlModel struct {
+	bun.BaseModel `bun:"table:login_state,alias:ls"`
+
+	Key         string     `bun:"key,pk"`
+	FailCount   int        `bun:"fail_count,notnull"`
+	FirstFailAt time.Time  `bun:"first_fail_at,notnull"`
+	LockedUntil *time.Time `bun:"locked_until,nullzero"`
+}
+
+func toDomainModel(sm *sqlModel) *Model {
+	return &Model{
+		Key:         sm.Key,
+		FailCount:   sm.FailCount,
+		FirstFailAt: sm.FirstFailAt,
+		LockedUntil: sm.LockedUntil,
+	}
+}
+
+func toSQLModel(m *Model) *sqlModel {
+	return &sqlModel{
+		Key:         m.Key,
+		FailCount:   m.FailCount,
+		FirstFailAt: m.FirstFailAt,
+		LockedUntil: m.LockedUntil,
+	}
+}
+
+type SQLRepositoryImpl struct {
+	db *bun.DB
+}
+
+func NewSQLRepository(db *bun.DB) Repository {
+	return &SQLRepositoryImpl{db: db}
+}
+
+// FindByKey retrieves login state by key
+func (r *SQLRepositoryImpl) FindByKey(ctx context.Context, key string) (*Model, error) {
+	var sm sqlModel
+	err := r.db.NewSelect().
+		Model(&sm).
+		Where("key = ?", key).
+		Scan(ctx)
+
+	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return toDomainModel(&sm), nil
+}
+
+// Create creates a new login state record
+func (r *SQLRepositoryImpl) Create(ctx context.Context, model *Model) (*Model, error) {
+	sm := toSQLModel(model)
+	_, err := r.db.NewInsert().Model(sm).Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return toDomainModel(sm), nil
+}
+
+// Update updates an existing login state record
+func (r *SQLRepositoryImpl) Update(ctx context.Context, key string, updateModel *UpdateModel) error {
+	query := r.db.NewUpdate().
+		Model((*sqlModel)(nil)).
+		Where("key = ?", key)
+
+	if updateModel.FailCount != nil {
+		query = query.Set("fail_count = ?", *updateModel.FailCount)
+	}
+	if updateModel.FirstFailAt != nil {
+		query = query.Set("first_fail_at = ?", *updateModel.FirstFailAt)
+	}
+	if updateModel.LockedUntil != nil {
+		query = query.Set("locked_until = ?", *updateModel.LockedUntil)
+	}
+
+	_, err := query.Exec(ctx)
+	return err
+}
+
+// Delete removes a login state record
+func (r *SQLRepositoryImpl) Delete(ctx context.Context, key string) error {
+	_, err := r.db.NewDelete().
+		Model((*sqlModel)(nil)).
+		Where("key = ?", key).
+		Exec(ctx)
+	return err
+}
+
+// IsLocked checks if a key is currently locked
+func (r *SQLRepositoryImpl) IsLocked(ctx context.Context, key string) (bool, time.Time, error) {
+	var sm sqlModel
+	err := r.db.NewSelect().
+		Model(&sm).
+		Where("key = ? AND locked_until > ?", key, time.Now()).
+		Scan(ctx)
+
+	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return false, time.Time{}, nil
+		}
+		return false, time.Time{}, err
+	}
+
+	if sm.LockedUntil != nil {
+		return true, *sm.LockedUntil, nil
+	}
+
+	return false, time.Time{}, nil
+}
+
+// OnFailure atomically handles failure logic with window and locking
+func (r *SQLRepositoryImpl) OnFailure(ctx context.Context, key string, now time.Time, window time.Duration, max int, lockout time.Duration) (bool, time.Time, error) {
+	var locked bool
+	var until time.Time
+
+	err := r.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		var sm sqlModel
+		err := tx.NewSelect().
+			Model(&sm).
+			Where("key = ?", key).
+			For("UPDATE").
+			Scan(ctx)
+
+		windowStart := now.Add(-window)
+
+		if err != nil {
+			if err.Error() == "sql: no rows in result set" {
+				// First failure for this key
+				sm = sqlModel{
+					Key:         key,
+					FailCount:   1,
+					FirstFailAt: now,
+					LockedUntil: nil,
+				}
+				_, err = tx.NewInsert().Model(&sm).Exec(ctx)
+				return err
+			}
+			return err
+		}
+
+		// Check if we're outside the window - reset if so
+		if sm.FirstFailAt.Before(windowStart) {
+			sm.FailCount = 1
+			sm.FirstFailAt = now
+			sm.LockedUntil = nil
+		} else {
+			// Within window, increment counter
+			sm.FailCount++
+
+			// Check if we need to lock
+			if sm.FailCount >= max {
+				lockUntil := now.Add(lockout)
+				sm.LockedUntil = &lockUntil
+				locked = true
+				until = lockUntil
+			}
+		}
+
+		_, err = tx.NewUpdate().
+			Model(&sm).
+			Where("key = ?", key).
+			Exec(ctx)
+
+		return err
+	})
+
+	return locked, until, err
+}


### PR DESCRIPTION
- Added 401 Unauthorized response definition to API documentation (Swagger and YAML).
- Updated Login controller to return a 401 status code on authentication failure.
- Integrated bruteforce protection middleware into the login route for enhanced security.