### PR TITLE
Add https monitor keyword and json query

### DIFF
--- a/apps/server/go.mod
+++ b/apps/server/go.mod
@@ -24,10 +24,12 @@ require (
 	github.com/pquerna/otp v1.5.0
 	github.com/redis/go-redis/v9 v9.11.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/sendgrid/sendgrid-go v3.16.1+incompatible
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.4
+	github.com/tidwall/gjson v1.18.0
 	github.com/uptrace/bun v1.2.14
 	github.com/uptrace/bun/dialect/mysqldialect v1.2.14
 	github.com/uptrace/bun/dialect/pgdialect v1.2.14
@@ -132,8 +134,9 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
-	github.com/sendgrid/sendgrid-go v3.16.1+incompatible // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/apps/server/go.sum
+++ b/apps/server/go.sum
@@ -300,6 +300,12 @@ github.com/swaggo/gin-swagger v1.6.0 h1:y8sxvQ3E20/RCyrXeFfg60r6H0Z+SwpTjMYsMm+z
 github.com/swaggo/gin-swagger v1.6.0/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
 github.com/swaggo/swag v1.16.4 h1:clWJtd9LStiG3VeijiCfOVODP6VpHtKdQy9ELFG3s1A=
 github.com/swaggo/swag v1.16.4/go.mod h1:VBsHJRsDvfYvqoiMKnsdwhNV9LEMHgEDZcyVYX0sxPg=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/apps/server/src/modules/healthcheck/executor/executor.go
+++ b/apps/server/src/modules/healthcheck/executor/executor.go
@@ -55,6 +55,8 @@ func NewExecutorRegistry(logger *zap.SugaredLogger, heartbeatService heartbeat.S
 	registry := make(map[string]Executor)
 
 	registry["http"] = NewHTTPExecutor(logger)
+	registry["http-keyword"] = NewHTTPExecutor(logger)
+	registry["http-json-query"] = NewHTTPExecutor(logger)
 	registry["push"] = NewPushExecutor(logger, heartbeatService)
 	registry["tcp"] = NewTCPExecutor(logger)
 	registry["ping"] = NewPingExecutor(logger)

--- a/apps/server/src/modules/healthcheck/executor/http.go
+++ b/apps/server/src/modules/healthcheck/executor/http.go
@@ -15,6 +15,7 @@ import (
 	"peekaping/src/modules/shared"
 	"peekaping/src/utils"
 	"peekaping/src/version"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/Azure/go-ntlmssp"
 	"github.com/go-playground/validator/v10"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 	"golang.org/x/net/proxy"
 )
@@ -123,6 +125,13 @@ type HTTPConfig struct {
 	MaxRedirects        int      `json:"max_redirects" validate:"omitempty,min=0"`
 	IgnoreTlsErrors     bool     `json:"ignore_tls_errors"`
 	CheckCertExpiry     bool     `json:"check_cert_expiry"`
+
+	// Response validation fields
+	Keyword        string `json:"keyword,omitempty"`
+	InvertKeyword  bool   `json:"invert_keyword,omitempty"`
+	JsonQuery      string `json:"json_query,omitempty"`
+	JsonCondition  string `json:"json_condition,omitempty" validate:"omitempty,oneof== != > < >= <="`
+	ExpectedValue  string `json:"expected_value,omitempty"`
 
 	// Authentication fields
 	AuthMethod        string `json:"authMethod" validate:"required,oneof=none basic oauth2-cc ntlm mtls"`
@@ -242,6 +251,91 @@ func isStatusAccepted(statusCode int, accepted []string) bool {
 		}
 	}
 	return false
+}
+
+// Helper to check keyword in response body
+func checkKeyword(responseBody, keyword string, invert bool) bool {
+	if keyword == "" {
+		return true // No keyword check needed
+	}
+	
+	found := strings.Contains(responseBody, keyword)
+	if invert {
+		return !found
+	}
+	return found
+}
+
+// Helper to check JSON query and expected value
+func checkJsonQuery(responseBody, jsonQuery, condition, expectedValue string) (bool, error) {
+	if jsonQuery == "" {
+		return true, nil // No JSON query check needed
+	}
+	
+	// Use "$" for raw response if no specific query is provided
+	query := jsonQuery
+	if query == "$" {
+		query = ""
+	}
+	
+	var result gjson.Result
+	if query == "" {
+		// Return the raw response body for comparison
+		result = gjson.Result{Type: gjson.String, Str: responseBody}
+	} else {
+		result = gjson.Get(responseBody, query)
+		if !result.Exists() {
+			return false, fmt.Errorf("JSON query path not found: %s", jsonQuery)
+		}
+	}
+	
+	if expectedValue == "" && condition == "" {
+		return result.Exists(), nil
+	}
+	
+	actualValue := result.String()
+	
+	// Default condition is equality
+	if condition == "" {
+		condition = "=="
+	}
+	
+	switch condition {
+	case "==":
+		return actualValue == expectedValue, nil
+	case "!=":
+		return actualValue != expectedValue, nil
+	case ">":
+		actualFloat, err1 := strconv.ParseFloat(actualValue, 64)
+		expectedFloat, err2 := strconv.ParseFloat(expectedValue, 64)
+		if err1 != nil || err2 != nil {
+			return strings.Compare(actualValue, expectedValue) > 0, nil
+		}
+		return actualFloat > expectedFloat, nil
+	case "<":
+		actualFloat, err1 := strconv.ParseFloat(actualValue, 64)
+		expectedFloat, err2 := strconv.ParseFloat(expectedValue, 64)
+		if err1 != nil || err2 != nil {
+			return strings.Compare(actualValue, expectedValue) < 0, nil
+		}
+		return actualFloat < expectedFloat, nil
+	case ">=":
+		actualFloat, err1 := strconv.ParseFloat(actualValue, 64)
+		expectedFloat, err2 := strconv.ParseFloat(expectedValue, 64)
+		if err1 != nil || err2 != nil {
+			return strings.Compare(actualValue, expectedValue) >= 0, nil
+		}
+		return actualFloat >= expectedFloat, nil
+	case "<=":
+		actualFloat, err1 := strconv.ParseFloat(actualValue, 64)
+		expectedFloat, err2 := strconv.ParseFloat(expectedValue, 64)
+		if err1 != nil || err2 != nil {
+			return strings.Compare(actualValue, expectedValue) <= 0, nil
+		}
+		return actualFloat <= expectedFloat, nil
+	default:
+		return false, fmt.Errorf("unsupported condition: %s", condition)
+	}
 }
 
 func buildProxyTransport(base *http.Transport, proxyModel *Proxy) http.RoundTripper {
@@ -498,6 +592,71 @@ func (h *HTTPExecutor) Execute(ctx context.Context, m *Monitor, proxyModel *Prox
 			StartTime: startTime,
 			EndTime:   endTime,
 			TLSInfo:   tlsInfo,
+		}
+	}
+
+	// Read response body for content validation
+	var responseBody string
+	if cfg.Keyword != "" || cfg.JsonQuery != "" {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return &Result{
+				Status:    shared.MonitorStatusDown,
+				Message:   fmt.Sprintf("Failed to read response body: %v", err),
+				StartTime: startTime,
+				EndTime:   endTime,
+				TLSInfo:   tlsInfo,
+			}
+		}
+		responseBody = string(bodyBytes)
+		h.logger.Debugf("Response body length: %d", len(responseBody))
+	}
+
+	// Check keyword if specified
+	if cfg.Keyword != "" {
+		if !checkKeyword(responseBody, cfg.Keyword, cfg.InvertKeyword) {
+			var message string
+			if cfg.InvertKeyword {
+				message = fmt.Sprintf("Keyword check failed: keyword '%s' found in response (expected absent)", cfg.Keyword)
+			} else {
+				message = fmt.Sprintf("Keyword check failed: keyword '%s' not found in response", cfg.Keyword)
+			}
+			return &Result{
+				Status:    shared.MonitorStatusDown,
+				Message:   message,
+				StartTime: startTime,
+				EndTime:   endTime,
+				TLSInfo:   tlsInfo,
+			}
+		}
+	}
+
+	// Check JSON query if specified
+	if cfg.JsonQuery != "" {
+		isValid, err := checkJsonQuery(responseBody, cfg.JsonQuery, cfg.JsonCondition, cfg.ExpectedValue)
+		if err != nil {
+			return &Result{
+				Status:    shared.MonitorStatusDown,
+				Message:   fmt.Sprintf("JSON query validation error: %v", err),
+				StartTime: startTime,
+				EndTime:   endTime,
+				TLSInfo:   tlsInfo,
+			}
+		}
+		if !isValid {
+			condition := cfg.JsonCondition
+			if condition == "" {
+				condition = "=="
+			}
+			message := fmt.Sprintf("JSON query validation failed: query '%s' with condition '%s' and expected value '%s'", 
+				cfg.JsonQuery, condition, cfg.ExpectedValue)
+			return &Result{
+				Status:    shared.MonitorStatusDown,
+				Message:   message,
+				StartTime: startTime,
+				EndTime:   endTime,
+				TLSInfo:   tlsInfo,
+			}
 		}
 	}
 

--- a/apps/web/src/app/monitors/components/http-json-query/index.tsx
+++ b/apps/web/src/app/monitors/components/http-json-query/index.tsx
@@ -7,12 +7,13 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import Advanced from "./advanced";
-import Authentication from "./authentication";
-import HttpOptions from "./options";
-
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import Advanced from "../http/advanced";
+import Authentication from "../http/authentication";
+import HttpOptions from "../http/options";
 import { Separator } from "@/components/ui/separator";
 import { Card, CardContent } from "@/components/ui/card";
+import { TypographyH4 } from "@/components/typography";
 import Notifications from "../shared/notifications";
 import Proxies from "../shared/proxies";
 import Intervals from "../shared/intervals";
@@ -21,12 +22,12 @@ import Tags from "../shared/tags";
 import { useMonitorFormContext } from "../../context/monitor-form-context";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
-import type { HttpForm } from "./schema";
+import type { HttpJsonQueryForm } from "./schema";
 import { deserialize, serialize } from "./schema";
 import { useEffect } from "react";
 import { useLocalizedTranslation } from "@/hooks/useTranslation";
 
-const Http = () => {
+const HttpJsonQuery = () => {
   const { t } = useLocalizedTranslation();
   const {
     form,
@@ -40,7 +41,7 @@ const Http = () => {
     monitor,
   } = useMonitorFormContext();
 
-  const onSubmit = (data: HttpForm) => {
+  const onSubmit = (data: HttpJsonQueryForm) => {
     const payload = serialize(data);
 
     if (mode === "create") {
@@ -74,7 +75,7 @@ const Http = () => {
   return (
     <Form {...form}>
       <form
-        onSubmit={form.handleSubmit((data) => onSubmit(data as HttpForm))}
+        onSubmit={form.handleSubmit((data) => onSubmit(data as HttpJsonQueryForm))}
         className="space-y-6 max-w-[600px]"
       >
         <Card>
@@ -98,6 +99,77 @@ const Http = () => {
                 </FormItem>
               )}
             />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="space-y-4">
+            <TypographyH4>JSON Query Expression</TypographyH4>
+            <div className="text-sm text-muted-foreground mb-4">
+              Parse and extract specific data from the server's JSON response using JSON query or use "$" for the raw response, if not expecting JSON. The result is then compared to the expected value, as strings. See <a href="https://jsonata.org" target="_blank" rel="noopener noreferrer" className="underline">jsonata.org</a> for documentation and use <a href="https://jsonata.org/try" target="_blank" rel="noopener noreferrer" className="underline">playground</a> to experiment with queries.
+            </div>
+            
+            <FormField
+              control={form.control}
+              name="json_query"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>JSON Query Expression</FormLabel>
+                  <FormControl>
+                    <Input 
+                      placeholder="$"
+                      {...field} 
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="json_condition"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Condition</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select condition" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="==">==</SelectItem>
+                        <SelectItem value="!=">!=</SelectItem>
+                        <SelectItem value=">">&gt;</SelectItem>
+                        <SelectItem value="<">&lt;</SelectItem>
+                        <SelectItem value=">=">&gt;=</SelectItem>
+                        <SelectItem value="<=">&lt;=</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="expected_value"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Expected Value</FormLabel>
+                    <FormControl>
+                      <Input 
+                        placeholder="Expected value"
+                        {...field} 
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
           </CardContent>
         </Card>
 
@@ -144,4 +216,4 @@ const Http = () => {
   );
 };
 
-export default Http;
+export default HttpJsonQuery;

--- a/apps/web/src/app/monitors/components/http-json-query/schema.ts
+++ b/apps/web/src/app/monitors/components/http-json-query/schema.ts
@@ -1,0 +1,230 @@
+import z from "zod";
+import { advancedDefaultValues, advancedSchema } from "../http/advanced";
+import { httpOptionsDefaultValues, httpOptionsSchema } from "../http/options";
+import { authenticationDefaultValues, authenticationSchema } from "../http/authentication";
+import { generalDefaultValues, generalSchema } from "../shared/general";
+import { intervalsDefaultValues, intervalsSchema } from "../shared/intervals";
+import { notificationsDefaultValues, notificationsSchema } from "../shared/notifications";
+import { proxiesDefaultValues, proxiesSchema } from "../shared/proxies";
+import { tagsDefaultValues, tagsSchema } from "../shared/tags";
+import type { MonitorMonitorResponseDto, MonitorCreateUpdateDto } from "@/api";
+
+export const httpJsonQuerySchema = z
+  .object({
+    type: z.literal("http-json-query"),
+    url: z.string().url({ message: "Invalid URL" }),
+    json_query: z.string().min(1, { message: "JSON query is required" }),
+    json_condition: z.enum(["==", "!=", ">", "<", ">=", "<="]).optional(),
+    expected_value: z.string().min(1, { message: "Expected value is required" }),
+  })
+  .merge(generalSchema)
+  .merge(intervalsSchema)
+  .merge(notificationsSchema)
+  .merge(proxiesSchema)
+  .merge(tagsSchema)
+  .merge(advancedSchema)
+  .merge(
+    z.object({
+      httpOptions: httpOptionsSchema,
+    })
+  )
+  .merge(
+    z.object({
+      authentication: authenticationSchema,
+    })
+  );
+
+export type HttpJsonQueryForm = z.infer<typeof httpJsonQuerySchema>;
+
+export const httpJsonQueryDefaultValues: HttpJsonQueryForm = {
+  type: "http-json-query",
+  url: "https://example.com",
+  json_query: "$",
+  json_condition: "==",
+  expected_value: "",
+
+  ...generalDefaultValues,
+  ...intervalsDefaultValues,
+  ...notificationsDefaultValues,
+  ...proxiesDefaultValues,
+  ...tagsDefaultValues,
+  ...advancedDefaultValues,
+
+  httpOptions: httpOptionsDefaultValues,
+  authentication: authenticationDefaultValues,
+};
+
+export const deserialize = (data: MonitorMonitorResponseDto): HttpJsonQueryForm => {
+  let config: Partial<HttpJsonQueryExecutorConfig> = {};
+  try {
+    config = data.config ? JSON.parse(data.config) : {};
+  } catch (error) {
+    console.error("Failed to parse HTTP JSON query monitor config:", error);
+    config = {};
+  }
+
+  // Build authentication object based on authMethod
+  const authMethod = config.authMethod || "none";
+  let authentication: HttpJsonQueryForm["authentication"];
+
+  switch (authMethod) {
+    case "basic":
+      authentication = {
+        authMethod: "basic",
+        basic_auth_user: config.basic_auth_user || "",
+        basic_auth_pass: config.basic_auth_pass || "",
+      };
+      break;
+    case "oauth2-cc":
+      authentication = {
+        authMethod: "oauth2-cc",
+        oauth_auth_method: (config.oauth_auth_method === "client_secret_post"
+          ? "client_secret_post"
+          : "client_secret_basic") as "client_secret_basic" | "client_secret_post",
+        oauth_token_url: config.oauth_token_url || "",
+        oauth_client_id: config.oauth_client_id || "",
+        oauth_client_secret: config.oauth_client_secret || "",
+        oauth_scopes: config.oauth_scopes || "",
+      };
+      break;
+    case "ntlm":
+      authentication = {
+        authMethod: "ntlm",
+        basic_auth_user: config.basic_auth_user || "",
+        basic_auth_pass: config.basic_auth_pass || "",
+        authDomain: config.authDomain || "",
+        authWorkstation: config.authWorkstation || "",
+      };
+      break;
+    case "mtls":
+      authentication = {
+        authMethod: "mtls",
+        tlsCert: config.tlsCert || "",
+        tlsKey: config.tlsKey || "",
+        tlsCa: config.tlsCa || "",
+      };
+      break;
+    default:
+      authentication = {
+        authMethod: "none",
+      };
+  }
+
+  return {
+    type: "http-json-query",
+    name: data.name || "My Monitor",
+    interval: data.interval || 60,
+    timeout: data.timeout || 16,
+    max_retries: data.max_retries || 3,
+    retry_interval: data.retry_interval || 60,
+    resend_interval: data.resend_interval || 10,
+    notification_ids: data.notification_ids || [],
+    tag_ids: data.tag_ids || [],
+    proxy_id: data.proxy_id || "",
+    url: config.url || "https://example.com",
+    accepted_statuscodes: config.accepted_statuscodes || ["2XX"],
+    max_redirects: config.max_redirects || 10,
+    ignore_tls_errors: config.ignore_tls_errors || false,
+    httpOptions: {
+      method: config.method || "GET",
+      encoding: config.encoding || "json",
+      headers: config.headers || '{ "Content-Type": "application/json" }',
+      body: config.body || "",
+    },
+    authentication,
+    check_cert_expiry: config.check_cert_expiry ?? false,
+    json_query: config.json_query || "$",
+    json_condition: (config.json_condition as "==" | "!=" | ">" | "<" | ">=" | "<=") || "==",
+    expected_value: config.expected_value || "",
+  };
+};
+
+export const serialize = (formData: HttpJsonQueryForm): MonitorCreateUpdateDto => {
+  const config: HttpJsonQueryExecutorConfig = {
+    url: formData.url,
+    method: formData.httpOptions.method,
+    headers: formData.httpOptions.headers,
+    encoding: formData.httpOptions.encoding,
+    body: formData.httpOptions.body,
+    accepted_statuscodes: formData.accepted_statuscodes as Array<"2XX" | "3XX" | "4XX" | "5XX">,
+    max_redirects: formData.max_redirects,
+    ignore_tls_errors: formData.ignore_tls_errors,
+    authMethod: formData.authentication.authMethod,
+    check_cert_expiry: formData.check_cert_expiry,
+
+    // JSON query validation fields
+    json_query: formData.json_query,
+    json_condition: formData.json_condition,
+    expected_value: formData.expected_value,
+
+    // Include authentication fields based on method
+    ...(formData.authentication.authMethod === "basic" && {
+      basic_auth_user: formData.authentication.basic_auth_user,
+      basic_auth_pass: formData.authentication.basic_auth_pass,
+    }),
+    ...(formData.authentication.authMethod === "oauth2-cc" && {
+      oauth_auth_method: formData.authentication.oauth_auth_method,
+      oauth_token_url: formData.authentication.oauth_token_url,
+      oauth_client_id: formData.authentication.oauth_client_id,
+      oauth_client_secret: formData.authentication.oauth_client_secret,
+      oauth_scopes: formData.authentication.oauth_scopes,
+    }),
+    ...(formData.authentication.authMethod === "ntlm" && {
+      basic_auth_user: formData.authentication.basic_auth_user,
+      basic_auth_pass: formData.authentication.basic_auth_pass,
+      authDomain: formData.authentication.authDomain,
+      authWorkstation: formData.authentication.authWorkstation,
+    }),
+    ...(formData.authentication.authMethod === "mtls" && {
+      tlsCert: formData.authentication.tlsCert,
+      tlsKey: formData.authentication.tlsKey,
+      tlsCa: formData.authentication.tlsCa,
+    }),
+  };
+
+  return {
+    type: "http-json-query",
+    name: formData.name,
+    interval: formData.interval,
+    max_retries: formData.max_retries,
+    retry_interval: formData.retry_interval,
+    notification_ids: formData.notification_ids,
+    tag_ids: formData.tag_ids,
+    proxy_id: formData.proxy_id,
+    resend_interval: formData.resend_interval,
+    timeout: formData.timeout,
+    config: JSON.stringify(config),
+  };
+};
+
+export interface HttpJsonQueryExecutorConfig {
+  url: string;
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS";
+  headers?: string;
+  encoding: "json" | "form" | "xml" | "text";
+  body?: string;
+  accepted_statuscodes: Array<"2XX" | "3XX" | "4XX" | "5XX">;
+  max_redirects?: number;
+  ignore_tls_errors: boolean;
+
+  // JSON query validation fields
+  json_query: string;
+  json_condition?: "==" | "!=" | ">" | "<" | ">=" | "<=";
+  expected_value: string;
+
+  // Authentication fields
+  authMethod: "none" | "basic" | "oauth2-cc" | "ntlm" | "mtls";
+  basic_auth_user?: string;
+  basic_auth_pass?: string;
+  authDomain?: string;
+  authWorkstation?: string;
+  oauth_auth_method?: string;
+  oauth_token_url?: string;
+  oauth_client_id?: string;
+  oauth_client_secret?: string;
+  oauth_scopes?: string;
+  tlsCert?: string;
+  tlsKey?: string;
+  tlsCa?: string;
+  check_cert_expiry: boolean;
+}

--- a/apps/web/src/app/monitors/components/http-keyword/index.tsx
+++ b/apps/web/src/app/monitors/components/http-keyword/index.tsx
@@ -7,12 +7,13 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import Advanced from "./advanced";
-import Authentication from "./authentication";
-import HttpOptions from "./options";
-
+import { Switch } from "@/components/ui/switch";
+import Advanced from "../http/advanced";
+import Authentication from "../http/authentication";
+import HttpOptions from "../http/options";
 import { Separator } from "@/components/ui/separator";
 import { Card, CardContent } from "@/components/ui/card";
+import { TypographyH4 } from "@/components/typography";
 import Notifications from "../shared/notifications";
 import Proxies from "../shared/proxies";
 import Intervals from "../shared/intervals";
@@ -21,12 +22,12 @@ import Tags from "../shared/tags";
 import { useMonitorFormContext } from "../../context/monitor-form-context";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
-import type { HttpForm } from "./schema";
+import type { HttpKeywordForm } from "./schema";
 import { deserialize, serialize } from "./schema";
 import { useEffect } from "react";
 import { useLocalizedTranslation } from "@/hooks/useTranslation";
 
-const Http = () => {
+const HttpKeyword = () => {
   const { t } = useLocalizedTranslation();
   const {
     form,
@@ -40,7 +41,7 @@ const Http = () => {
     monitor,
   } = useMonitorFormContext();
 
-  const onSubmit = (data: HttpForm) => {
+  const onSubmit = (data: HttpKeywordForm) => {
     const payload = serialize(data);
 
     if (mode === "create") {
@@ -74,7 +75,7 @@ const Http = () => {
   return (
     <Form {...form}>
       <form
-        onSubmit={form.handleSubmit((data) => onSubmit(data as HttpForm))}
+        onSubmit={form.handleSubmit((data) => onSubmit(data as HttpKeywordForm))}
         className="space-y-6 max-w-[600px]"
       >
         <Card>
@@ -95,6 +96,50 @@ const Http = () => {
                     <Input placeholder="https://" {...field} />
                   </FormControl>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="space-y-4">
+            <TypographyH4>Keyword Validation</TypographyH4>
+            
+            <FormField
+              control={form.control}
+              name="keyword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Keyword</FormLabel>
+                  <FormControl>
+                    <Input 
+                      placeholder="Search keyword in plain HTML or JSON response. The search is case-sensitive."
+                      {...field} 
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="invert_keyword"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                  <div className="space-y-0.5">
+                    <FormLabel>Invert Keyword</FormLabel>
+                    <div className="text-sm text-muted-foreground">
+                      Look for the keyword to be absent rather than present.
+                    </div>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
                 </FormItem>
               )}
             />
@@ -144,4 +189,4 @@ const Http = () => {
   );
 };
 
-export default Http;
+export default HttpKeyword;

--- a/apps/web/src/app/monitors/components/http-keyword/schema.ts
+++ b/apps/web/src/app/monitors/components/http-keyword/schema.ts
@@ -1,0 +1,225 @@
+import z from "zod";
+import { advancedDefaultValues, advancedSchema } from "../http/advanced";
+import { httpOptionsDefaultValues, httpOptionsSchema } from "../http/options";
+import { authenticationDefaultValues, authenticationSchema } from "../http/authentication";
+import { generalDefaultValues, generalSchema } from "../shared/general";
+import { intervalsDefaultValues, intervalsSchema } from "../shared/intervals";
+import { notificationsDefaultValues, notificationsSchema } from "../shared/notifications";
+import { proxiesDefaultValues, proxiesSchema } from "../shared/proxies";
+import { tagsDefaultValues, tagsSchema } from "../shared/tags";
+import type { MonitorMonitorResponseDto, MonitorCreateUpdateDto } from "@/api";
+
+export const httpKeywordSchema = z
+  .object({
+    type: z.literal("http-keyword"),
+    url: z.string().url({ message: "Invalid URL" }),
+    keyword: z.string().min(1, { message: "Keyword is required" }),
+    invert_keyword: z.boolean().optional(),
+  })
+  .merge(generalSchema)
+  .merge(intervalsSchema)
+  .merge(notificationsSchema)
+  .merge(proxiesSchema)
+  .merge(tagsSchema)
+  .merge(advancedSchema)
+  .merge(
+    z.object({
+      httpOptions: httpOptionsSchema,
+    })
+  )
+  .merge(
+    z.object({
+      authentication: authenticationSchema,
+    })
+  );
+
+export type HttpKeywordForm = z.infer<typeof httpKeywordSchema>;
+
+export const httpKeywordDefaultValues: HttpKeywordForm = {
+  type: "http-keyword",
+  url: "https://example.com",
+  keyword: "",
+  invert_keyword: false,
+
+  ...generalDefaultValues,
+  ...intervalsDefaultValues,
+  ...notificationsDefaultValues,
+  ...proxiesDefaultValues,
+  ...tagsDefaultValues,
+  ...advancedDefaultValues,
+
+  httpOptions: httpOptionsDefaultValues,
+  authentication: authenticationDefaultValues,
+};
+
+export const deserialize = (data: MonitorMonitorResponseDto): HttpKeywordForm => {
+  let config: Partial<HttpKeywordExecutorConfig> = {};
+  try {
+    config = data.config ? JSON.parse(data.config) : {};
+  } catch (error) {
+    console.error("Failed to parse HTTP keyword monitor config:", error);
+    config = {};
+  }
+
+  // Build authentication object based on authMethod
+  const authMethod = config.authMethod || "none";
+  let authentication: HttpKeywordForm["authentication"];
+
+  switch (authMethod) {
+    case "basic":
+      authentication = {
+        authMethod: "basic",
+        basic_auth_user: config.basic_auth_user || "",
+        basic_auth_pass: config.basic_auth_pass || "",
+      };
+      break;
+    case "oauth2-cc":
+      authentication = {
+        authMethod: "oauth2-cc",
+        oauth_auth_method: (config.oauth_auth_method === "client_secret_post"
+          ? "client_secret_post"
+          : "client_secret_basic") as "client_secret_basic" | "client_secret_post",
+        oauth_token_url: config.oauth_token_url || "",
+        oauth_client_id: config.oauth_client_id || "",
+        oauth_client_secret: config.oauth_client_secret || "",
+        oauth_scopes: config.oauth_scopes || "",
+      };
+      break;
+    case "ntlm":
+      authentication = {
+        authMethod: "ntlm",
+        basic_auth_user: config.basic_auth_user || "",
+        basic_auth_pass: config.basic_auth_pass || "",
+        authDomain: config.authDomain || "",
+        authWorkstation: config.authWorkstation || "",
+      };
+      break;
+    case "mtls":
+      authentication = {
+        authMethod: "mtls",
+        tlsCert: config.tlsCert || "",
+        tlsKey: config.tlsKey || "",
+        tlsCa: config.tlsCa || "",
+      };
+      break;
+    default:
+      authentication = {
+        authMethod: "none",
+      };
+  }
+
+  return {
+    type: "http-keyword",
+    name: data.name || "My Monitor",
+    interval: data.interval || 60,
+    timeout: data.timeout || 16,
+    max_retries: data.max_retries || 3,
+    retry_interval: data.retry_interval || 60,
+    resend_interval: data.resend_interval || 10,
+    notification_ids: data.notification_ids || [],
+    tag_ids: data.tag_ids || [],
+    proxy_id: data.proxy_id || "",
+    url: config.url || "https://example.com",
+    accepted_statuscodes: config.accepted_statuscodes || ["2XX"],
+    max_redirects: config.max_redirects || 10,
+    ignore_tls_errors: config.ignore_tls_errors || false,
+    httpOptions: {
+      method: config.method || "GET",
+      encoding: config.encoding || "json",
+      headers: config.headers || '{ "Content-Type": "application/json" }',
+      body: config.body || "",
+    },
+    authentication,
+    check_cert_expiry: config.check_cert_expiry ?? false,
+    keyword: config.keyword || "",
+    invert_keyword: config.invert_keyword || false,
+  };
+};
+
+export const serialize = (formData: HttpKeywordForm): MonitorCreateUpdateDto => {
+  const config: HttpKeywordExecutorConfig = {
+    url: formData.url,
+    method: formData.httpOptions.method,
+    headers: formData.httpOptions.headers,
+    encoding: formData.httpOptions.encoding,
+    body: formData.httpOptions.body,
+    accepted_statuscodes: formData.accepted_statuscodes as Array<"2XX" | "3XX" | "4XX" | "5XX">,
+    max_redirects: formData.max_redirects,
+    ignore_tls_errors: formData.ignore_tls_errors,
+    authMethod: formData.authentication.authMethod,
+    check_cert_expiry: formData.check_cert_expiry,
+
+    // Keyword validation fields
+    keyword: formData.keyword,
+    invert_keyword: formData.invert_keyword,
+
+    // Include authentication fields based on method
+    ...(formData.authentication.authMethod === "basic" && {
+      basic_auth_user: formData.authentication.basic_auth_user,
+      basic_auth_pass: formData.authentication.basic_auth_pass,
+    }),
+    ...(formData.authentication.authMethod === "oauth2-cc" && {
+      oauth_auth_method: formData.authentication.oauth_auth_method,
+      oauth_token_url: formData.authentication.oauth_token_url,
+      oauth_client_id: formData.authentication.oauth_client_id,
+      oauth_client_secret: formData.authentication.oauth_client_secret,
+      oauth_scopes: formData.authentication.oauth_scopes,
+    }),
+    ...(formData.authentication.authMethod === "ntlm" && {
+      basic_auth_user: formData.authentication.basic_auth_user,
+      basic_auth_pass: formData.authentication.basic_auth_pass,
+      authDomain: formData.authentication.authDomain,
+      authWorkstation: formData.authentication.authWorkstation,
+    }),
+    ...(formData.authentication.authMethod === "mtls" && {
+      tlsCert: formData.authentication.tlsCert,
+      tlsKey: formData.authentication.tlsKey,
+      tlsCa: formData.authentication.tlsCa,
+    }),
+  };
+
+  return {
+    type: "http-keyword",
+    name: formData.name,
+    interval: formData.interval,
+    max_retries: formData.max_retries,
+    retry_interval: formData.retry_interval,
+    notification_ids: formData.notification_ids,
+    tag_ids: formData.tag_ids,
+    proxy_id: formData.proxy_id,
+    resend_interval: formData.resend_interval,
+    timeout: formData.timeout,
+    config: JSON.stringify(config),
+  };
+};
+
+export interface HttpKeywordExecutorConfig {
+  url: string;
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS";
+  headers?: string;
+  encoding: "json" | "form" | "xml" | "text";
+  body?: string;
+  accepted_statuscodes: Array<"2XX" | "3XX" | "4XX" | "5XX">;
+  max_redirects?: number;
+  ignore_tls_errors: boolean;
+
+  // Keyword validation fields
+  keyword: string;
+  invert_keyword?: boolean;
+
+  // Authentication fields
+  authMethod: "none" | "basic" | "oauth2-cc" | "ntlm" | "mtls";
+  basic_auth_user?: string;
+  basic_auth_pass?: string;
+  authDomain?: string;
+  authWorkstation?: string;
+  oauth_auth_method?: string;
+  oauth_token_url?: string;
+  oauth_client_id?: string;
+  oauth_client_secret?: string;
+  oauth_scopes?: string;
+  tlsCert?: string;
+  tlsKey?: string;
+  tlsCa?: string;
+  check_cert_expiry: boolean;
+}

--- a/apps/web/src/app/monitors/components/monitor-registry.ts
+++ b/apps/web/src/app/monitors/components/monitor-registry.ts
@@ -1,6 +1,8 @@
 import type { MonitorMonitorResponseDto } from "@/api";
 import type { MonitorForm } from "../context/monitor-form-context";
 import { deserialize as httpDeserialize } from "./http/schema";
+import { deserialize as httpKeywordDeserialize } from "./http-keyword/schema";
+import { deserialize as httpJsonQueryDeserialize } from "./http-json-query/schema";
 import { deserialize as tcpDeserialize } from "./tcp";
 import { deserialize as pingDeserialize } from "./ping";
 import { deserialize as dnsDeserialize } from "./dns";
@@ -20,6 +22,8 @@ import TCPForm from "./tcp";
 import PingForm from "./ping";
 import DNSForm from "./dns";
 import HttpForm from "./http";
+import HttpKeywordForm from "./http-keyword";
+import HttpJsonQueryForm from "./http-json-query";
 import PushForm from "./push";
 import DockerForm from "./docker";
 import GRPCKeywordForm from "./grpc-keyword";
@@ -55,6 +59,14 @@ const monitorTypeRegistry: Record<string, MonitorTypeConfig> = {
   http: {
     deserialize: httpDeserialize,
     component: HttpForm,
+  },
+  "http-keyword": {
+    deserialize: httpKeywordDeserialize,
+    component: HttpKeywordForm,
+  },
+  "http-json-query": {
+    deserialize: httpJsonQueryDeserialize,
+    component: HttpJsonQueryForm,
   },
   tcp: {
     deserialize: tcpDeserialize,

--- a/apps/web/src/app/monitors/components/shared/general.tsx
+++ b/apps/web/src/app/monitors/components/shared/general.tsx
@@ -37,6 +37,14 @@ const General = () => {
       description: t("monitors.form.type.http"),
     },
     {
+      type: "http-keyword",
+      description: "HTTP(s) - Keyword",
+    },
+    {
+      type: "http-json-query",
+      description: "HTTP(s) - Json Query",
+    },
+    {
       type: "tcp",
       description: t("monitors.form.type.tcp"),
     },

--- a/apps/web/src/app/monitors/context/monitor-form-context.tsx
+++ b/apps/web/src/app/monitors/context/monitor-form-context.tsx
@@ -40,6 +40,8 @@ import {
   httpSchema,
   type HttpForm,
 } from "../components/http/schema";
+import { httpKeywordSchema, type HttpKeywordForm } from "../components/http-keyword/schema";
+import { httpJsonQuerySchema, type HttpJsonQueryForm } from "../components/http-json-query/schema";
 import { tcpSchema, type TCPForm } from "../components/tcp";
 import { pingSchema, type PingForm } from "../components/ping";
 import { dnsSchema, type DNSForm } from "../components/dns";
@@ -70,6 +72,8 @@ import { useLocalizedTranslation } from "@/hooks/useTranslation";
 
 const formSchema = z.discriminatedUnion("type", [
   httpSchema,
+  httpKeywordSchema,
+  httpJsonQuerySchema,
   tcpSchema,
   pingSchema,
   dnsSchema,
@@ -89,6 +93,8 @@ const formSchema = z.discriminatedUnion("type", [
 
 export type MonitorForm =
   | HttpForm
+  | HttpKeywordForm
+  | HttpJsonQueryForm
   | TCPForm
   | PingForm
   | DNSForm


### PR DESCRIPTION
Add "HTTP(s) - Keyword" and "HTTP(s) - Json Query" monitor types to enable response content validation.

These new monitor types allow users to check for the presence or absence of a specific keyword in the HTTP response body, or to extract a value using a JSON query expression and compare it against an expected value, providing more granular control over HTTP(s) health checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6865201-bd24-4d6c-9c85-10c45bf08fb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6865201-bd24-4d6c-9c85-10c45bf08fb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

