### PR TITLE
fix(forms): preserve current name when resetting form in create mode …

### DIFF
--- a/apps/web/src/app/monitors/components/dns/index.tsx
+++ b/apps/web/src/app/monitors/components/dns/index.tsx
@@ -182,7 +182,12 @@ const DNSForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(dnsDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...dnsDefaultValues,
+        name: currentName || dnsDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/docker/index.tsx
+++ b/apps/web/src/app/monitors/components/docker/index.tsx
@@ -378,7 +378,12 @@ const DockerForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(dockerDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...dockerDefaultValues,
+        name: currentName || dockerDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/kafka-producer/index.tsx
+++ b/apps/web/src/app/monitors/components/kafka-producer/index.tsx
@@ -78,7 +78,12 @@ const KafkaProducerForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(kafkaProducerDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...kafkaProducerDefaultValues,
+        name: currentName || kafkaProducerDefaultValues.name,
+      });
       setBrokers(kafkaProducerDefaultValues.brokers);
     }
   }, [mode, form]);

--- a/apps/web/src/app/monitors/components/mongodb/index.tsx
+++ b/apps/web/src/app/monitors/components/mongodb/index.tsx
@@ -184,7 +184,12 @@ const MongoDBForm = () => {
   // Reset form with default values when in create mode
   useEffect(() => {
     if (mode === "create") {
-      form.reset(mongodbDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...mongodbDefaultValues,
+        name: currentName || mongodbDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/mqtt/index.tsx
+++ b/apps/web/src/app/monitors/components/mqtt/index.tsx
@@ -207,7 +207,12 @@ const MQTTForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(mqttDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...mqttDefaultValues,
+        name: currentName || mqttDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/mysql/index.tsx
+++ b/apps/web/src/app/monitors/components/mysql/index.tsx
@@ -163,7 +163,12 @@ const MySQLForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(mysqlDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...mysqlDefaultValues,
+        name: currentName || mysqlDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/ping/index.tsx
+++ b/apps/web/src/app/monitors/components/ping/index.tsx
@@ -154,7 +154,12 @@ const PingForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(pingDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...pingDefaultValues,
+        name: currentName || pingDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/postgres/index.tsx
+++ b/apps/web/src/app/monitors/components/postgres/index.tsx
@@ -49,7 +49,12 @@ const PostgresFormComponent = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(postgresDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...postgresDefaultValues,
+        name: currentName || postgresDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/rabbitmq/index.tsx
+++ b/apps/web/src/app/monitors/components/rabbitmq/index.tsx
@@ -152,7 +152,12 @@ const RabbitMQForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(rabbitMQDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...rabbitMQDefaultValues,
+        name: currentName || rabbitMQDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/redis/index.tsx
+++ b/apps/web/src/app/monitors/components/redis/index.tsx
@@ -201,7 +201,12 @@ const RedisForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(redisDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...redisDefaultValues,
+        name: currentName || redisDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/snmp/index.tsx
+++ b/apps/web/src/app/monitors/components/snmp/index.tsx
@@ -213,7 +213,12 @@ const SnmpForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(snmpDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...snmpDefaultValues,
+        name: currentName || snmpDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/sqlserver/index.tsx
+++ b/apps/web/src/app/monitors/components/sqlserver/index.tsx
@@ -61,7 +61,12 @@ const SQLServerForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(sqlServerDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...sqlServerDefaultValues,
+        name: currentName || sqlServerDefaultValues.name,
+      });
     }
   }, [mode, form]);
 

--- a/apps/web/src/app/monitors/components/tcp/index.tsx
+++ b/apps/web/src/app/monitors/components/tcp/index.tsx
@@ -150,7 +150,12 @@ const TCPForm = () => {
 
   useEffect(() => {
     if (mode === "create") {
-      form.reset(tcpDefaultValues);
+      // Preserve the current name when resetting form
+      const currentName = form.getValues("name");
+      form.reset({
+        ...tcpDefaultValues,
+        name: currentName || tcpDefaultValues.name,
+      });
     }
   }, [mode, form]);
 


### PR DESCRIPTION
fixes #151

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the `name` field is retained when resetting forms in create mode across all monitor components.
> 
> - **Frontend – Monitors forms**: retain `name` on `form.reset(...)` in create mode by merging current `name` with defaults
>   - Updated: `dns`, `docker`, `kafka-producer`, `mongodb`, `mqtt`, `mysql`, `ping`, `postgres`, `rabbitmq`, `redis`, `snmp`, `sqlserver`, `tcp`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c42d6f46edbe318a4a52644bfeb926903a573a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->