### PR TITLE
feat: prevent refetch on window focus to avoid form resets

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,6 +12,7 @@ const queryClient = new QueryClient({
     queries: {
       retry: false,
       staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: false, // Prevent refetch when switching tabs to avoid form resets
     },
     mutations: {
       retry: false,


### PR DESCRIPTION
- Added `refetchOnWindowFocus: false` to the query client configuration to prevent data refetching when switching tabs, enhancing user experience by avoiding unintended form resets.

Fixes #161 