### PR TITLE
Fix #254 stale healthcheck task preventing http monitor

### DIFF
--- a/Dockerfile.test.failing.http
+++ b/Dockerfile.test.failing.http
@@ -1,0 +1,13 @@
+FROM golang:1.25.6-alpine3.23 AS builder
+
+WORKDIR /app
+COPY test_utils/test_http_failing/main.go test_utils/test_http_failing/go.mod /app/
+
+RUN go build -o /app/main /app/main.go
+
+FROM scratch
+
+COPY --from=builder /app/main /app/main
+EXPOSE 8080
+
+CMD ["/app/main"]

--- a/docker-compose.bundle.sqlite.test.failing.http.yml
+++ b/docker-compose.bundle.sqlite.test.failing.http.yml
@@ -1,0 +1,31 @@
+#
+# Test stack for dangling healthcheck
+#
+services:
+  peekaping:
+    build:
+      context: .
+      dockerfile: Dockerfile.bundle.sqlite
+    restart: unless-stopped
+    ports:
+      - "8383:8383"
+    env_file:
+      - .env
+    environment:
+      - DB_TYPE=sqlite
+      - DB_NAME=/app/data/peekaping.db
+    volumes:
+      # Database data persistence
+      - ./.data/sqlite:/app/data
+      # Application logs persistence
+      - ./.data/logs:/var/log/supervisor
+      # Optional: Custom Caddyfile override
+      # - ./custom-Caddyfile:/etc/caddy/Caddyfile:ro
+    container_name: peekaping-bundle-sqlite
+  http:
+    build:
+      context: .
+      dockerfile: Dockerfile.test.failing.http
+    restart: unless-stopped
+    ports:
+      - "8080:8080"

--- a/test_utils/test_http_failing/go.mod
+++ b/test_utils/test_http_failing/go.mod
@@ -1,0 +1,3 @@
+module peekaping_test_failing
+
+go 1.25.6

--- a/test_utils/test_http_failing/main.go
+++ b/test_utils/test_http_failing/main.go
@@ -1,0 +1,36 @@
+// Test http server for dangling healthcheck
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+)
+
+// A handler that consumes the request but never responds.
+func hangHandler(w http.ResponseWriter, r *http.Request) {
+	// Drain the request body so the client doesn’t get a reset.
+	// We ignore any read error – the client may close early.
+	_, _ = io.Copy(io.Discard, r.Body)
+	_ = r.Body.Close()
+
+	log.Println("incoming request accepted, blocking response")
+
+	// Block forever – do NOT call w.WriteHeader or w.Write.
+	select {} // blocks indefinitely
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", hangHandler)
+
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: mux,
+	}
+
+	log.Println("Hanging HTTP server listening on :8080")
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+}


### PR DESCRIPTION
Fix #254 by dropping healthcheck task if archived and older than ((mon.Timeout + mon.RetryInterval) * mon.MaxRetries) seconds