### PR TITLE
fix(maintenance): resolve SAME_AS_SERVER timezone from TZ env var

### DIFF
--- a/apps/server/infra/Dockerfile.api
+++ b/apps/server/infra/Dockerfile.api
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 GOFLAGS="-trimpath" go build -o main -ldflags="-s -w" ./cmd/ap
 
 # Start a new stage from scratch
 FROM alpine
+RUN apk add --no-cache tzdata
 
 WORKDIR /app
 

--- a/apps/server/infra/Dockerfile.ingester
+++ b/apps/server/infra/Dockerfile.ingester
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 GOFLAGS="-trimpath" go build -o main -ldflags="-s -w" ./cmd/in
 
 # Start a new stage from scratch
 FROM alpine
+RUN apk add --no-cache tzdata
 
 WORKDIR /app
 

--- a/apps/server/infra/Dockerfile.producer
+++ b/apps/server/infra/Dockerfile.producer
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 GOFLAGS="-trimpath" go build -o main -ldflags="-s -w" ./cmd/pr
 
 # Start a new stage from scratch
 FROM alpine
+RUN apk add --no-cache tzdata
 
 WORKDIR /app
 

--- a/apps/server/infra/Dockerfile.worker
+++ b/apps/server/infra/Dockerfile.worker
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 GOFLAGS="-trimpath" go build -o main -ldflags="-s -w" ./cmd/wo
 
 # Start a new stage from scratch
 FROM alpine
+RUN apk add --no-cache tzdata
 
 USER 65532:65532
 

--- a/apps/server/internal/modules/maintenance/utils/time_utils.go
+++ b/apps/server/internal/modules/maintenance/utils/time_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"os"
 	"time"
 )
 
@@ -48,7 +49,10 @@ func (tu *TimeUtils) CalculateDurationFromTimes(startTime, endTime string) (int,
 // LoadTimezone loads a timezone location, with fallback to UTC if invalid
 func (tu *TimeUtils) LoadTimezone(timezone string) *time.Location {
 	if timezone == "SAME_AS_SERVER" {
-		timezone = time.Now().Location().String()
+	    timezone = os.Getenv("TZ")
+	    if timezone == "" {
+	        timezone = time.Now().Location().String()
+	    }
 	}
 
 	loc, err := time.LoadLocation(timezone)


### PR DESCRIPTION
**Root cause:** In Alpine-based container images without `tzdata`, `time.LoadLocation("Europe/Kyiv")` fails silently and falls back to UTC. Additionally, `time.Now().Location().String()` always returns `UTC` regardless of `TZ` environment variable when `/usr/share/zoneinfo` is not available.

**Fix:**
1. Read timezone from `TZ` env var first for `SAME_AS_SERVER` case, fall back to `time.Now().Location()` for non-containerized deployments
2. Add `tzdata` to all Alpine-based Dockerfiles so `time.LoadLocation()` can resolve named timezones correctly

**Fixes #261**