### PR TITLE
feat(grafana-oncall): enrich notification payload with monitor details, tags and type-specific fields

### DIFF
--- a/apps/server/internal/modules/shared/monitor.model.go
+++ b/apps/server/internal/modules/shared/monitor.model.go
@@ -38,6 +38,9 @@ type Monitor struct {
 	ProxyId   string `json:"proxy_id"`
 	PushToken string `json:"push_token"`
 
+	// Tags associated with this monitor (names only)
+	Tags []string `json:"tags,omitempty"`
+
 	// Last heartbeat for push monitors
 	LastHeartbeat *HeartBeatModel `json:"last_heartbeat,omitempty"`
 


### PR DESCRIPTION
**Problem**

The existing Grafana OnCall provider sent minimal payload with only `title`, `message` and `state`, making it impossible to build meaningful alert grouping and routing in Grafana OnCall.

**Changes**

**1. `shared/monitor.model.go`**
Added `Tags []string` field to `Monitor` model to make monitor tags available across the codebase.

**2. `monitor/monitor.sql.repository.go`**
Extended `FindByID` to load tag names via a second query joining `monitor_tags` and `tags` tables.

**3. `notification_channel/providers/grafana_oncall.go`**
Enriched payload with:
- Common fields for all monitor types: `status`, `ping_ms`, `retries`, `time`, `monitor_id`, `monitor_type`, `tags`
- HTTP monitors (`http`, `http-keyword`, `http-json-query`): `monitor_url`, `http_status_code`
- Host-based monitors (`tcp`, `ping`, `dns`, `grpc-keyword`): `monitor_host`
- DB/infra monitors (`mysql`, `postgres`, `redis`, etc.): base payload only – DSN may contain credentials

**Example payloads**

Alert:
```json
{
  "title": "example.com is down",
  "message": "HTTP request failed with status: 503",
  "state": "alerting",
  "status": "DOWN",
  "ping_ms": 685,
  "retries": 2,
  "time": "2026-02-27T00:21:00Z",
  "http_status_code": "503",
  "monitor_id": "3215c0fd-...",
  "monitor_type": "http",
  "monitor_url": "https://example.com",
  "tags": ["severity:critical", "country:ua"]
}
```

Resolve:
```json
{
  "title": "example.com is up",
  "message": "200 - 200 OK",
  "state": "ok",
  "status": "UP",
  "ping_ms": 167,
  "retries": 0,
  "time": "2026-02-27T00:25:00Z",
  "http_status_code": "200",
  "monitor_id": "3215c0fd-...",
  "monitor_type": "http",
  "monitor_url": "https://example.com",
  "tags": ["severity:critical", "country:ua"]
}