### PR TITLE
fix(web): show target host/record in monitor header for TCP and DNS monitors

### DIFF
--- a/apps/web/src/app/monitors/view/format-monitor-target.ts
+++ b/apps/web/src/app/monitors/view/format-monitor-target.ts
@@ -1,0 +1,77 @@
+import type { MonitorMonitorResponseDto } from "@/api";
+
+type MonitorConfig = Record<string, unknown>;
+
+const parseConfig = (config?: string): MonitorConfig => {
+  if (!config) return {};
+
+  try {
+    const parsed = JSON.parse(config);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (error) {
+    console.error("Failed to parse monitor config:", error);
+    return {};
+  }
+};
+
+const getString = (config: MonitorConfig, key: string): string | null => {
+  const value = config[key];
+  return typeof value === "string" && value.trim() ? value : null;
+};
+
+const getNumber = (config: MonitorConfig, key: string): number | null => {
+  const value = config[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const formatHostPort = (host: string | null, port: number | null): string | null => {
+  if (!host) return null;
+  return port ? `${host}:${port}` : host;
+};
+
+export const formatMonitorTarget = (
+  monitor?: Pick<MonitorMonitorResponseDto, "type" | "config"> | null
+): string | null => {
+  if (!monitor?.type) return null;
+
+  const config = parseConfig(monitor.config);
+
+  switch (monitor.type) {
+    case "http":
+    case "http-keyword":
+    case "http-json-query":
+      return getString(config, "url");
+    case "tcp":
+      return formatHostPort(getString(config, "host"), getNumber(config, "port"));
+    case "dns": {
+      const host = getString(config, "host");
+      if (!host) return null;
+
+      const resolveType = getString(config, "resolve_type");
+      const resolver = formatHostPort(
+        getString(config, "resolver_server"),
+        getNumber(config, "port")
+      );
+
+      if (resolveType && resolver) return `${host} (${resolveType} @ ${resolver})`;
+      if (resolveType) return `${host} (${resolveType})`;
+      if (resolver) return `${host} (@ ${resolver})`;
+
+      return host;
+    }
+    case "ping":
+      return getString(config, "host");
+    case "grpc-keyword":
+      return getString(config, "grpcUrl");
+    case "docker":
+      return getString(config, "container_id");
+    default:
+      return null;
+  }
+};

--- a/apps/web/src/app/monitors/view/page.tsx
+++ b/apps/web/src/app/monitors/view/page.tsx
@@ -49,6 +49,7 @@ import { BackButton } from "@/components/back-button";
 import dayjs from "dayjs";
 import { useLocalizedTranslation } from "@/hooks/useTranslation";
 import clsx from "clsx";
+import { formatMonitorTarget } from "./format-monitor-target";
 
 function formatDuration(ms: number, t: (key: string) => string): string {
   // Handle negative durations (clock skew) by returning empty string
@@ -117,6 +118,11 @@ const MonitorPage = () => {
   });
 
   const monitor = data?.data;
+  const monitorTarget = formatMonitorTarget(monitor);
+  const monitorTargetHref =
+    monitorTarget?.startsWith("http://") || monitorTarget?.startsWith("https://")
+      ? monitorTarget
+      : undefined;
 
   const hasCertCheckExpire = useMemo(() => {
     if (!monitor) return false;
@@ -163,16 +169,6 @@ const MonitorPage = () => {
         : undefined,
     };
   }, [tlsData]);
-
-  // Safe JSON parsing with error handling
-  const config = useMemo(() => {
-    try {
-      return JSON.parse(monitor?.config ?? "{}");
-    } catch (error) {
-      console.error("Failed to parse monitor config:", error);
-      return {};
-    }
-  }, [monitor?.config]);
 
   const deleteMutation = useMutation({
     ...deleteMonitorsByIdMutation({
@@ -425,16 +421,21 @@ const MonitorPage = () => {
         <BackButton to="/monitors" />
         <div className="pl-4">
           <span className="text-sm text-muted-foreground mr-2">
-            {monitor?.type} {t("monitors.view.monitor_for")}
+            {monitor?.type}
+            {monitorTarget ? ` ${t("monitors.view.monitor_for")}` : null}
           </span>
-          <a
-            href={config?.url ?? "#"}
-            className="text-blue-500 hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {config?.url ?? ""}
-          </a>
+          {monitorTargetHref ? (
+            <a
+              href={monitorTargetHref}
+              className="text-blue-500 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {monitorTarget}
+            </a>
+          ) : monitorTarget ? (
+            <span className="text-muted-foreground">{monitorTarget}</span>
+          ) : null}
         </div>
 
         <div className="mt-4 mb-4">


### PR DESCRIPTION
## Summary

The monitor detail header currently only renders the configured target for HTTP monitors. TCP and DNS monitors show just the monitor type with no indication of the host:port or DNS record being monitored, forcing users to open the edit dialog to confirm what each monitor is pointed at.

This PR adds a `formatMonitorTarget(monitor)` helper that returns the most identifying configured value per monitor type, and uses it in the monitor view header. HTTP behavior is unchanged. TCP renders `host:port`, DNS renders `record (type @ resolver:port)`.

## Changes

- `apps/web/src/app/monitors/view/format-monitor-target.ts` - adds a small config parser/formatter for monitor header targets.
- `apps/web/src/app/monitors/view/page.tsx` - uses the formatter in the detail header and only links HTTP targets.

## Test plan

- `git diff --check` passed.
- Attempted targeted lint/typecheck, but this environment does not have `pnpm`/`corepack`; installing dependencies with `npx pnpm@9.0.0 install --frozen-lockfile` failed with `ENOSPC: no space left on device` before eslint/tsc became available.
- Manual code inspection: existing HTTP URL display path is preserved; TCP now formats host+port; DNS now formats host + resolve type + resolver.
- Unit tests were not added because `apps/web/src` does not currently contain component/helper tests and I did not scaffold a new test framework.

## Notes

- Fixes #269 
- The helper also covers trivial targets for ping, gRPC keyword, and Docker monitors; push monitors intentionally render no target.
- i18n: no new user-facing copy was added; the existing `monitors.view.monitor_for` translation is reused.