### PR TITLE
adds optional HMAC-SHA256 signing to webhook notification channel

### DIFF
--- a/apps/server/internal/modules/notification_channel/providers/webhook.go
+++ b/apps/server/internal/modules/notification_channel/providers/webhook.go
@@ -3,6 +3,9 @@ package providers
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,16 +14,38 @@ import (
 	"peekaping/internal/modules/heartbeat"
 	"peekaping/internal/modules/monitor"
 	"peekaping/internal/version"
+	"strconv"
+	"time"
 
 	liquid "github.com/osteele/liquid"
 	"go.uber.org/zap"
 )
+
+// Header names used when webhook signing is enabled.
+const (
+	webhookSignatureHeader = "X-Webhook-Signature-V2"
+	webhookTimestampHeader = "X-Webhook-Timestamp"
+)
+
+// signBody returns the lowercase hex HMAC-SHA256 of body using secret.
+func signBody(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// signWebhookPayload signs the V2 payload "{timestamp}.{body}" so the timestamp
+// is bound into the signature. Receivers reconstruct the same string to verify.
+func signWebhookPayload(timestamp string, body []byte, secret string) string {
+	return signBody(append([]byte(timestamp+"."), body...), secret)
+}
 
 type WebhookConfig struct {
 	WebhookURL               string `json:"webhook_url" validate:"required,url"`
 	WebhookContentType       string `json:"webhook_content_type" validate:"required,oneof=json form-data custom"`
 	WebhookCustomBody        string `json:"webhook_custom_body"`
 	WebhookAdditionalHeaders string `json:"webhook_additional_headers"`
+	WebhookSigningSecret     string `json:"webhook_signing_secret"`
 }
 
 type WebhookSender struct {
@@ -75,7 +100,7 @@ func (w *WebhookSender) Send(
 	}
 
 	// Prepare request body and headers based on content type
-	var body io.Reader
+	var bodyBytes []byte
 	headers := make(map[string]string)
 
 	switch cfg.WebhookContentType {
@@ -85,7 +110,7 @@ func (w *WebhookSender) Send(
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON body: %w", err)
 		}
-		body = bytes.NewBuffer(jsonBytes)
+		bodyBytes = jsonBytes
 		headers["Content-Type"] = "application/json"
 
 	case "form-data":
@@ -106,7 +131,7 @@ func (w *WebhookSender) Send(
 
 		writer.Close()
 
-		body = &buf
+		bodyBytes = buf.Bytes()
 		headers["Content-Type"] = writer.FormDataContentType()
 
 		// Debug logging
@@ -126,15 +151,23 @@ func (w *WebhookSender) Send(
 			return fmt.Errorf("failed to render custom body template: %w", err)
 		}
 
-		body = bytes.NewBufferString(rendered)
+		bodyBytes = []byte(rendered)
 		headers["Content-Type"] = "text/plain"
 
 	default:
 		return fmt.Errorf("unsupported content type: %s", cfg.WebhookContentType)
 	}
 
+	// Sign "{timestamp}.{body}" with HMAC-SHA256 when a signing secret is configured.
+	// Binding the timestamp into the signature lets receivers reject replayed requests.
+	if cfg.WebhookSigningSecret != "" {
+		timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+		headers[webhookSignatureHeader] = signWebhookPayload(timestamp, bodyBytes, cfg.WebhookSigningSecret)
+		headers[webhookTimestampHeader] = timestamp
+	}
+
 	// Create HTTP request (always POST)
-	req, err := http.NewRequestWithContext(ctx, "POST", cfg.WebhookURL, body)
+	req, err := http.NewRequestWithContext(ctx, "POST", cfg.WebhookURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)
 	}

--- a/apps/server/internal/modules/notification_channel/providers/webhook_test.go
+++ b/apps/server/internal/modules/notification_channel/providers/webhook_test.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"peekaping/internal/modules/heartbeat"
+	"peekaping/internal/modules/monitor"
+
+	"go.uber.org/zap"
+)
+
+// captureWebhook starts a test server that records the first request's body and headers,
+// then runs Send against it with the given config fragment. contentType/secret/customBody
+// are interpolated into a webhook config JSON pointing at the test server.
+func captureWebhook(t *testing.T, contentType, secret, customBody string) (body []byte, headers http.Header) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		headers = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sender := NewWebhookSender(zap.NewNop().Sugar())
+	cfg := fmt.Sprintf(`{
+		"webhook_url": %q,
+		"webhook_content_type": %q,
+		"webhook_custom_body": %q,
+		"webhook_signing_secret": %q
+	}`, srv.URL, contentType, customBody, secret)
+
+	err := sender.Send(
+		context.Background(),
+		cfg,
+		"test message",
+		&monitor.Model{ID: "m1", Name: "Test Monitor"},
+		&heartbeat.Model{Msg: "down"},
+	)
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	return body, headers
+}
+
+// Well-known HMAC-SHA256 test vector:
+// HMAC-SHA256("The quick brown fox jumps over the lazy dog", key="key")
+// pins the algorithm (SHA-256), encoding (lowercase hex), and inputs (body, secret).
+func TestSignBody_KnownVector(t *testing.T) {
+	got := signBody([]byte("The quick brown fox jumps over the lazy dog"), "key")
+	want := "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
+	if got != want {
+		t.Errorf("signBody = %q, want %q", got, want)
+	}
+}
+
+// reconstructSignature rebuilds the expected V2 signature the way a receiver would:
+// HMAC-SHA256 over "{timestamp}.{body}" using the shared secret.
+func reconstructSignature(headers http.Header, body []byte, secret string) string {
+	ts := headers.Get(webhookTimestampHeader)
+	return signBody([]byte(ts+"."+string(body)), secret)
+}
+
+// Pins the V2 signed-payload construction: HMAC over "{timestamp}.{body}",
+// dot-delimited, timestamp first. Independent of the live clock.
+func TestSignWebhookPayload_JoinsTimestampDotBody(t *testing.T) {
+	got := signWebhookPayload("1700000000", []byte("hello"), "key")
+	want := signBody([]byte("1700000000.hello"), "key")
+	if got != want {
+		t.Errorf("signWebhookPayload = %q, want %q (HMAC of \"1700000000.hello\")", got, want)
+	}
+}
+
+func TestWebhookSend_SignsTimestampDotBody(t *testing.T) {
+	body, headers := captureWebhook(t, "json", "shh", "")
+
+	got := headers.Get(webhookSignatureHeader)
+	if got == "" {
+		t.Fatalf("expected signature on header %q, got none", webhookSignatureHeader)
+	}
+	want := reconstructSignature(headers, body, "shh")
+	if got != want {
+		t.Errorf("signature = %q, want %q (HMAC of {timestamp}.{body})", got, want)
+	}
+}
+
+func TestWebhookSend_SendsRecentTimestamp(t *testing.T) {
+	before := time.Now().Unix()
+	_, headers := captureWebhook(t, "json", "shh", "")
+	after := time.Now().Unix()
+
+	raw := headers.Get(webhookTimestampHeader)
+	if raw == "" {
+		t.Fatalf("expected %q header when signing, got none", webhookTimestampHeader)
+	}
+	ts, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("timestamp %q is not a unix integer: %v", raw, err)
+	}
+	if ts < before || ts > after {
+		t.Errorf("timestamp %d outside send window [%d, %d]", ts, before, after)
+	}
+}
+
+func TestWebhookSend_NoSecretNoSignatureOrTimestamp(t *testing.T) {
+	_, headers := captureWebhook(t, "json", "", "")
+
+	if got := headers.Get(webhookSignatureHeader); got != "" {
+		t.Errorf("expected no signature header without a secret, got %q", got)
+	}
+	if got := headers.Get(webhookTimestampHeader); got != "" {
+		t.Errorf("expected no timestamp header without a secret, got %q", got)
+	}
+}
+
+// Signing must cover the exact bytes sent for every content type.
+func TestWebhookSend_SignsAllContentTypes(t *testing.T) {
+	cases := []struct {
+		contentType string
+		customBody  string
+	}{
+		{"json", ""},
+		{"form-data", ""},
+		{"custom", "monitor {{ monitor.name }} is {{ heartbeat.msg }}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.contentType, func(t *testing.T) {
+			body, headers := captureWebhook(t, tc.contentType, "shh", tc.customBody)
+			got := headers.Get(webhookSignatureHeader)
+			want := reconstructSignature(headers, body, "shh")
+			if got != want {
+				t.Errorf("signature = %q, want %q (HMAC of {timestamp}.{%s body})", got, want, tc.contentType)
+			}
+		})
+	}
+}

--- a/apps/web/src/app/notification-channels/integrations/webhook-form.tsx
+++ b/apps/web/src/app/notification-channels/integrations/webhook-form.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import {
   FormField,
   FormItem,
@@ -21,6 +22,7 @@ export const schema = z.object({
   webhook_content_type: z.enum(["json", "form-data", "custom"]),
   webhook_custom_body: z.string().optional(),
   webhook_additional_headers: z.string().optional(),
+  webhook_signing_secret: z.string().optional(),
 });
 
 export type WebhookFormValues = z.infer<typeof schema>;
@@ -34,6 +36,7 @@ export const defaultValues: WebhookFormValues = {
     "Body": "{{ msg }}"
 }`,
   webhook_additional_headers: "",
+  webhook_signing_secret: "",
 };
 
 export const displayName = "Webhook";
@@ -45,12 +48,21 @@ export default function WebhookForm() {
   const [showAdditionalHeaders, setShowAdditionalHeaders] = React.useState(
     !!form.getValues("webhook_additional_headers")
   );
+  const [showSigning, setShowSigning] = React.useState(
+    !!form.getValues("webhook_signing_secret")
+  );
 
   React.useEffect(() => {
     if (!showAdditionalHeaders) {
       form.setValue("webhook_additional_headers", "");
     }
   }, [showAdditionalHeaders, form]);
+
+  React.useEffect(() => {
+    if (!showSigning) {
+      form.setValue("webhook_signing_secret", "");
+    }
+  }, [showSigning, form]);
 
   const headersPlaceholder = `Example:
 {
@@ -177,6 +189,35 @@ export default function WebhookForm() {
                   {...field}
                 />
               </FormControl>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="webhook_signing_secret"
+        render={({ field }) => (
+          <FormItem>
+            <div className="flex items-center gap-2 mb-2">
+              <Switch checked={showSigning} onCheckedChange={setShowSigning} />
+              <FormLabel>{t("notifications.form.webhook.signing_label")}</FormLabel>
+            </div>
+            <FormDescription>
+              {t("notifications.form.webhook.signing_description")}
+            </FormDescription>
+            {showSigning && (
+              <>
+                <FormLabel>{t("notifications.form.webhook.signing_secret_label")}</FormLabel>
+                <FormControl>
+                  <PasswordInput
+                    placeholder={t("notifications.form.webhook.signing_secret_placeholder")}
+                    required
+                    {...field}
+                  />
+                </FormControl>
+              </>
             )}
             <FormMessage />
           </FormItem>

--- a/apps/web/src/i18n/locales/en-US.json
+++ b/apps/web/src/i18n/locales/en-US.json
@@ -1027,7 +1027,11 @@
         "request_body_description_form_data": "Content will be sent as multipart/form-data. You can decode it using <strong>json_decode($_POST['data'])</strong> in PHP.",
         "request_body_description_json": "Content will be sent as JSON with \"application/json\" header.",
         "request_body_label": "Request Body",
-        "request_body_placeholder": "Select content type"
+        "request_body_placeholder": "Select content type",
+        "signing_description": "Sign the request body with HMAC-SHA256 using a shared secret. The signature is sent in the X-Webhook-Signature-V2 header and the send time in X-Webhook-Timestamp.",
+        "signing_label": "Enable HMAC signature",
+        "signing_secret_label": "Signing Secret",
+        "signing_secret_placeholder": "Your shared secret"
       }
     },
     "important": "Important Notifications",


### PR DESCRIPTION
signs the outgoing request body for all content types when a secret is set, hex HMAC in a configurable header (default X-Webhook-Signature-V2)

Disabled:
<img width="963" height="758" alt="image" src="https://github.com/user-attachments/assets/5b296979-ddd5-4459-a4dd-8a6b1a322a9a" />

Enabled:
<img width="970" height="765" alt="image" src="https://github.com/user-attachments/assets/aa8dc4f6-48c4-40f3-a48f-8fed577712fe" />

